### PR TITLE
ci: build dev and main artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,18 @@
 name: Build
 
 on:
+  push:
+    branches: [dev, main]
   release:
     types: [published]
   workflow_dispatch:
 
 permissions:
   contents: write
+
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
   macos:
@@ -16,6 +22,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Resolve artifact name
+        id: artifact
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "suffix=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "suffix=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -27,7 +42,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install frontend dependencies
-        run: npm ci
+        run: npm ci --no-audit --no-fund
 
       - name: Build macOS app
         run: npm run tauri:build
@@ -35,9 +50,10 @@ jobs:
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4
         with:
-          name: prism-player-macos-dmg
+          name: prism-player-${{ steps.artifact.outputs.suffix }}-macos-dmg
           path: src-tauri/target/release/bundle/dmg/*.dmg
           if-no-files-found: error
+          retention-days: ${{ github.event_name == 'release' && 90 || 14 }}
 
       - name: Attach DMG to GitHub release
         if: github.event_name == 'release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,20 @@ jobs:
         with:
           components: clippy
 
+      - name: Install Linux Tauri dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            curl \
+            file \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            wget
+
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary
- run the macOS DMG build workflow on pushes to dev and main
- keep release-published builds attaching the DMG to GitHub Releases
- name branch artifacts by ref and keep branch artifacts for 14 days

## Validation
- npm test

Note: local cargo/Tauri packaging was not runnable from this shell because cargo is not available here.