### PR TITLE
fix: bundle generated app icons

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,12 @@ jobs:
         id: artifact
         run: |
           if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "suffix=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+            suffix="${{ github.event.release.tag_name }}"
           else
-            echo "suffix=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            suffix="${GITHUB_REF_NAME}"
           fi
+          suffix="$(echo "$suffix" | tr '/\\:*?\"<>|' '-')"
+          echo "suffix=$suffix" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,6 +27,13 @@
   "bundle": {
     "active": true,
     "targets": ["dmg"],
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
     "macOS": {
       "signingIdentity": "-",
       "minimumSystemVersion": "13.0"


### PR DESCRIPTION
## Summary
- explicitly configures the Tauri bundle icon list so generated Prism icons are embedded in the macOS app bundle

## Validation
- npm run test
- local Tauri CLI config passed far enough to invoke cargo metadata; local shell does not have cargo available, so the macOS bundle check will run through GitHub Actions
