### PR TITLE
ci: align workflows with release branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [dev, main]
+    branches: [dev, release]
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [dev, main]
+    branches: [dev, release]
   push:
-    branches: [dev, main]
+    branches: [dev, release]
 
 permissions:
   contents: read

--- a/.github/workflows/enforce-main-source.yml
+++ b/.github/workflows/enforce-main-source.yml
@@ -1,8 +1,8 @@
-name: Enforce main PR source
+name: Enforce release PR source
 
 on:
   pull_request:
-    branches: [main]
+    branches: [release]
 
 permissions:
   contents: read
@@ -20,6 +20,6 @@ jobs:
             echo "Source branch '$HEAD' is allowed."
             exit 0
           fi
-          echo "::error::PRs to main must come from 'dev' (or release-please). This PR's head is '$HEAD'."
-          echo "Open this PR against 'dev' instead, then promote dev to main when the release candidate is ready."
+          echo "::error::PRs to release must come from 'dev' (or release-please). This PR's head is '$HEAD'."
+          echo "Open this PR against 'dev' instead, then promote dev to release when the release candidate is ready."
           exit 1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: Release Please
 
 on:
   push:
-    branches: [main]
+    branches: [release]
 
 permissions:
   contents: write
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          target-branch: main
+          target-branch: release
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,9 +2,9 @@ name: Security
 
 on:
   pull_request:
-    branches: [dev, main]
+    branches: [dev, release]
   push:
-    branches: [dev, main]
+    branches: [dev, release]
   schedule:
     - cron: "0 8 * * 1"
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ npm run tauri:build
 
 ## Repository Workflow
 
-Development should happen on short-lived branches and merge through pull requests into `dev`. The `dev` branch is the integration lane for active feature work; `main` is the release branch.
+Development should happen on short-lived branches and merge through pull requests into `dev`. The `dev` branch is the integration lane for active feature work; `release` is the release branch.
 
 1. Create a branch from `dev`.
 2. Make small, reviewable commits using Conventional Commits.
@@ -82,8 +82,8 @@ Development should happen on short-lived branches and merge through pull request
 4. Wait for CI and security checks to pass.
 5. Squash or merge using a Conventional Commit-style title.
 6. Let multiple feature branches settle together on `dev`.
-7. When `dev` is ready to ship, open a release-candidate PR from `dev` into `main`.
-8. release-please opens or updates the release PR after changes land on `main`.
+7. When `dev` is ready to ship, open a release-candidate PR from `dev` into `release`.
+8. release-please opens or updates the release PR after changes land on `release`.
 9. Merging the release PR creates the tag and GitHub release.
 10. The release packaging workflow builds and attaches the macOS DMG.
 
@@ -94,7 +94,7 @@ Recommended branch names:
 - `docs/public-readme`
 - `chore/ci-security-release-flow`
 
-PRs directly into `main` are intentionally blocked unless the source branch is `dev` or release-please automation.
+PRs directly into `release` are intentionally blocked unless the source branch is `dev` or release-please automation.
 
 ## Commit Style
 
@@ -134,7 +134,7 @@ Release automation is documented in [docs/RELEASE.md](docs/RELEASE.md).
 At a high level:
 
 - Normal feature and fix PRs merge to `dev`.
-- Release-candidate PRs merge from `dev` into `main`.
+- Release-candidate PRs merge from `dev` into `release`.
 - release-please maintains a release PR based on Conventional Commit history.
 - The release PR updates `package.json`, `package-lock.json`, `src-tauri/tauri.conf.json`, and `CHANGELOG.md`.
 - Merging the release PR creates a GitHub release.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -5,18 +5,18 @@ Prism Player uses pull requests, Conventional Commits, and release-please to kee
 ## Branches
 
 - `dev` is the integration branch for active work.
-- `main` is the protected release branch.
+- `release` is the protected release branch.
 - Feature, fix, documentation, and maintenance work should happen on short-lived branches from `dev`.
 - Normal pull requests target `dev` and must pass CI and security checks before merge.
-- Pull requests into `main` should only come from `dev` for a release candidate, or from release-please automation.
+- Pull requests into `release` should only come from `dev` for a release candidate, or from release-please automation.
 
 ## Required Checks
 
-The `CI` workflow should be required by branch protection on `dev` and `main`. It installs dependencies with `npm ci`, runs ESLint, runs TypeScript type checking, builds the frontend, and checks the Tauri Rust crate with `cargo check` and `cargo clippy`.
+The `CI` workflow should be required by branch protection on `dev` and `release`. It installs dependencies with `npm ci`, runs ESLint, runs TypeScript type checking, builds the frontend, and checks the Tauri Rust crate with `cargo check` and `cargo clippy`.
 
 The `Security` workflow should also be required for pull requests. It runs GitHub dependency review, npm production dependency audit, Rust dependency audit, CodeQL, and Gitleaks secret scanning.
 
-The `Enforce main PR source` workflow should be required on `main`. It blocks direct feature PRs into `main`, while allowing `dev -> main` release-candidate PRs and release-please PRs.
+The `Enforce release PR source` workflow should be required on `release`. It blocks direct feature PRs into `release`, while allowing `dev -> release` release-candidate PRs and release-please PRs.
 
 The macOS packaging workflow is intentionally separate from pull request CI because Tauri bundling is slower and produces release artifacts.
 
@@ -34,9 +34,9 @@ Use Conventional Commits for commit messages and pull request titles:
 
 1. Work merges to `dev` through feature, fix, docs, chore, build, test, and CI pull requests.
 2. Several branches can be tested together on `dev` before anything reaches users.
-3. When `dev` is ready to ship, open a `dev -> main` release-candidate PR.
+3. When `dev` is ready to ship, open a `dev -> release` release-candidate PR.
 4. Merge the release-candidate PR after checks pass and the combined changes look right.
-5. The `Release Please` workflow evaluates Conventional Commits on `main`.
+5. The `Release Please` workflow evaluates Conventional Commits on `release`.
 6. release-please opens or updates a release PR.
 7. The release PR contains:
    - `CHANGELOG.md` updates
@@ -66,7 +66,7 @@ Before merging a release PR, check:
 - The app builds locally or CI is green.
 - Any new privacy, signing, platform, or server-API behavior is documented.
 
-Before merging a `dev -> main` release-candidate PR, check:
+Before merging a `dev -> release` release-candidate PR, check:
 
 - All intended feature branches for the release are already merged into `dev`.
 - CI and security checks are green.


### PR DESCRIPTION
## Summary
- target CI, security, build, Release Please, and the release-source guard at the new `release` lane
- update release workflow documentation from `main` to `release`

## Validation
- YAML parse passed for all GitHub workflows
- git diff --check passed
- local lint/typecheck/build were not runnable because this new isolated worktree has no installed node dependencies; GitHub CI will run the full checks.