### PR TITLE
ci: add on-demand Windows installer builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches: [dev, release]
   release:
     types: [published]
   workflow_dispatch:
@@ -12,7 +10,7 @@ permissions:
 
 concurrency:
   group: build-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
   macos:
@@ -64,4 +62,45 @@ jobs:
         run: |
           for dmg in src-tauri/target/release/bundle/dmg/*.dmg; do
             gh release upload "${{ github.event.release.tag_name }}" "$dmg" --clobber
+          done
+
+  windows:
+    name: Windows installer
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install frontend dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Build NSIS installer
+        run: npm run tauri:build -- --bundles nsis
+
+      - name: Upload NSIS artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: prism-player-${{ github.event.release.tag_name || github.ref_name }}-windows-installer
+          path: src-tauri/target/release/bundle/nsis/*.exe
+          if-no-files-found: error
+          retention-days: ${{ github.event_name == 'release' && 90 || 14 }}
+
+      - name: Attach installer to GitHub release
+        if: github.event_name == 'release'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for installer in src-tauri/target/release/bundle/nsis/*.exe; do
+            gh release upload "${{ github.event.release.tag_name }}" "$installer" --clobber
           done

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Development should happen on short-lived branches and merge through pull request
 7. When `dev` is ready to ship, open a release-candidate PR from `dev` into `release`.
 8. release-please opens or updates the release PR after changes land on `release`.
 9. Merging the release PR creates the tag and GitHub release.
-10. The release packaging workflow builds and attaches the macOS DMG.
+10. The release packaging workflow builds and attaches the macOS DMG and Windows installer. Run it manually from Actions for an on-demand development artifact.
 
 Recommended branch names:
 
@@ -138,7 +138,7 @@ At a high level:
 - release-please maintains a release PR based on Conventional Commit history.
 - The release PR updates `package.json`, `package-lock.json`, `src-tauri/tauri.conf.json`, and `CHANGELOG.md`.
 - Merging the release PR creates a GitHub release.
-- The packaging workflow builds the macOS DMG and uploads it to the release.
+- The packaging workflow builds the macOS DMG and Windows installer and uploads them to the release.
 
 ## Privacy
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -18,7 +18,7 @@ The `Security` workflow should also be required for pull requests. It runs GitHu
 
 The `Enforce release PR source` workflow should be required on `release`. It blocks direct feature PRs into `release`, while allowing `dev -> release` release-candidate PRs and release-please PRs.
 
-The macOS packaging workflow is intentionally separate from pull request CI because Tauri bundling is slower and produces release artifacts.
+The packaging workflow is intentionally separate from pull request CI because Tauri bundling is slower and produces release artifacts. Run it manually from Actions when a development build is needed; published releases automatically build and attach both the macOS DMG and Windows NSIS installer.
 
 ## Commit Convention
 
@@ -45,7 +45,7 @@ Use Conventional Commits for commit messages and pull request titles:
    - `src-tauri/tauri.conf.json` version bump
 8. Merge the release PR when the changelog and version look right.
 9. release-please creates the Git tag and GitHub release.
-10. The `Build` workflow runs on the published release, builds the macOS DMG, stores it as a workflow artifact, and uploads it to the GitHub release.
+10. The `Build` workflow runs on the published release, builds the macOS DMG and Windows NSIS installer, stores them as workflow artifacts, and uploads them to the GitHub release.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- build a Windows NSIS installer alongside the macOS DMG
- make development packaging on-demand through workflow dispatch
- keep packaging automatic for published releases and attach both installers

## Validation
- npm ci --no-audit --no-fund
- npm run lint
- npm run typecheck
- npm run build
- YAML parse and git diff --check