### PR TITLE
fix(windows): hide console window in release builds

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 fn main() {
     prism_player_lib::run()
 }


### PR DESCRIPTION
## Summary
- configure packaged Windows builds to use the Windows subsystem
- prevents the blank console window from appearing alongside Prism
- preserves console output for debug builds

## Validation
- `npm run test` (typecheck + lint)
- `npm run build`
- Rust/Cargo check deferred to CI because Cargo is not installed on the local host

## Windows verification
After this merges, dispatch the Build workflow on `dev` and install/run the generated NSIS artifact. The console window should not appear.