### PR TITLE
ci: announce Prism releases in Discord

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Resolve artifact name
+        id: artifact
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "release") {
+            $suffix = "${{ github.event.release.tag_name }}"
+          } else {
+            $suffix = "${{ github.ref_name }}"
+          }
+          $suffix = $suffix -replace '[\\/:*?"<>|]', '-'
+          "suffix=$suffix" >> $env:GITHUB_OUTPUT
+
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
@@ -90,7 +102,7 @@ jobs:
       - name: Upload NSIS artifact
         uses: actions/upload-artifact@v7
         with:
-          name: prism-player-${{ github.event.release.tag_name || github.ref_name }}-windows-installer
+          name: prism-player-${{ steps.artifact.outputs.suffix }}-windows-installer
           path: src-tauri/target/release/bundle/nsis/*.exe
           if-no-files-found: error
           retention-days: ${{ github.event_name == 'release' && 90 || 14 }}
@@ -104,3 +116,43 @@ jobs:
           for installer in src-tauri/target/release/bundle/nsis/*.exe; do
             gh release upload "${{ github.event.release.tag_name }}" "$installer" --clobber
           done
+
+  announce-discord:
+    name: Discord release announcement
+    needs: [macos, windows]
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Post release announcement
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          if [[ -z "$DISCORD_WEBHOOK_URL" ]]; then
+            echo "::error::Set the DISCORD_RELEASE_WEBHOOK_URL repository secret before publishing a release."
+            exit 1
+          fi
+
+          description="${RELEASE_BODY:-Initial alpha release.}"
+          if (( ${#description} > 3900 )); then
+            description="${description:0:3897}..."
+          fi
+
+          payload="$(jq -n \
+            --arg content '<@&1536269011468419072>' \
+            --arg title "${RELEASE_NAME:-Prism Player $RELEASE_TAG}" \
+            --arg url "$RELEASE_URL" \
+            --arg description "$description" \
+            --argjson allowed_mentions '{"parse":["roles"]}' \
+            '{content: $content, allowed_mentions: $allowed_mentions, embeds: [{title: $title, url: $url, description: $description, color: 5934141, footer: {text: "Prism Player release"}}]}')"
+
+          curl --fail --retry 3 --retry-all-errors --silent --show-error \
+            -H 'Content-Type: application/json' \
+            --data "$payload" \
+            "$DISCORD_WEBHOOK_URL"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -20,6 +20,8 @@ The `Enforce release PR source` workflow should be required on `release`. It blo
 
 The packaging workflow is intentionally separate from pull request CI because Tauri bundling is slower and produces release artifacts. Run it manually from Actions when a development build is needed; published releases automatically build and attach both the macOS DMG and Windows NSIS installer.
 
+After both release installers are attached, the same workflow posts the release notes to Discord and pings the Prism release role. Set the `DISCORD_RELEASE_WEBHOOK_URL` repository secret to the Discord channel webhook before publishing a release.
+
 ## Commit Convention
 
 Use Conventional Commits for commit messages and pull request titles:


### PR DESCRIPTION
## Summary

- Post a Discord release announcement only after the macOS and Windows release artifacts upload.
- Ping the Prism release role with the GitHub release notes and link.
- Document the required DISCORD_RELEASE_WEBHOOK_URL repository secret.
- Sanitize manual Windows artifact names for slash-containing branch names.

## Validation

- GitHub Actions YAML parsed successfully.
- git diff --check passed.

## Release setup

Before publishing, add DISCORD_RELEASE_WEBHOOK_URL as a repository Actions secret using the webhook URL for the desired Discord release channel.