### PR TITLE
ci: preserve pre-1 minor versioning

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "node",
       "package-name": "prism-player",
+      "bump-minor-pre-major": true,
       "include-component-in-tag": false,
       "extra-files": [
         "src-tauri/tauri.conf.json"


### PR DESCRIPTION
## Summary

Configure Release Please to keep feature releases below v1.0.0 while Prism is in its alpha phase. With the initial 0.0.0 baseline, this makes the generated release v0.1.0 instead of v1.0.0.

## Validation

- JSON parsed successfully.
- git diff --check passed.

## Follow-up

After merging this PR to dev, promote dev to release again. Release Please will update the existing generated release PR to v0.1.0.