### PR TITLE
feat: show available updates in app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -362,6 +362,7 @@ const PRISM_LATEST_RELEASE_API = "https://api.github.com/repos/kylejschultz/pris
 const PRISM_REPOSITORY_URL = "https://github.com/kylejschultz/prism-player";
 const PRISM_DISCORD_URL = "https://discord.gg/aDEBQq3XtN";
 const APP_VERSION = packageJson.version;
+const APP_COMMIT_SHA = __APP_COMMIT_SHA__;
 const BEACON_ENDPOINT = "https://beacon.kjschultz.com/ping";
 const CLIENT_ID = "PrismPlayer";
 const HAVE_FUTURE_DATA = 3;
@@ -5091,6 +5092,7 @@ function SettingsView({
             <span className="settings-label">Installed version</span>
             <strong>v{APP_VERSION}</strong>
           </div>
+          <span className="about-commit-sha" title={`Commit ${APP_COMMIT_SHA}`}>SHA {APP_COMMIT_SHA}</span>
           <div className="about-update-action">
             {availableUpdate ? <a className="connect-button compact-button" href={availableUpdate.releaseUrl} target="_blank" rel="noreferrer">
               <Download size={15} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
   ChevronRight,
   CheckCircle2,
   Disc3,
+  Download,
   History,
   Heart,
   Home,
@@ -52,6 +53,11 @@ type RepeatMode = "off" | "all" | "one";
 type RightPanelTab = "queue" | "nowPlaying" | "lyrics";
 type LyricsStatus = "idle" | "loading" | "ready" | "empty" | "error";
 
+type AvailableUpdate = {
+  version: string;
+  releaseUrl: string;
+};
+
 function shuffled<T>(items: T[]) {
   const next = [...items];
   for (let index = next.length - 1; index > 0; index -= 1) {
@@ -59,6 +65,24 @@ function shuffled<T>(items: T[]) {
     [next[index], next[swapIndex]] = [next[swapIndex], next[index]];
   }
   return next;
+}
+
+function versionParts(version: string) {
+  return version.replace(/^v/, "").split(".").map((part) => Number.parseInt(part, 10) || 0);
+}
+
+function isVersionNewer(candidate: string, current: string) {
+  const candidateParts = versionParts(candidate);
+  const currentParts = versionParts(current);
+  const length = Math.max(candidateParts.length, currentParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    if ((candidateParts[index] ?? 0) !== (currentParts[index] ?? 0)) {
+      return (candidateParts[index] ?? 0) > (currentParts[index] ?? 0);
+    }
+  }
+
+  return false;
 }
 
 type NavidromeConfig = {
@@ -75,6 +99,7 @@ type AppSettings = {
   sidebarPlaylistLimit: number;
   analyticsEnabled: boolean;
   analyticsPromptDismissed: boolean;
+  updateDismissedVersion: string;
   coverWashEnabled: boolean;
   lowPerformanceMode: boolean;
   radioStationUrl: string;
@@ -327,6 +352,8 @@ const RIGHT_PANEL_TAB_KEY = "prism-player.rightPanelTab";
 const SIDEBAR_COLLAPSED_KEY = "prism-player.sidebarCollapsed";
 const INSTALL_ID_KEY = "prism-player.installId";
 const ANALYTICS_LAST_PING_KEY = "prism-player.analyticsLastPing";
+const PRISM_RELEASES_URL = "https://github.com/kylejschultz/prism-player/releases/latest";
+const PRISM_LATEST_RELEASE_API = "https://api.github.com/repos/kylejschultz/prism-player/releases/latest";
 const APP_VERSION = packageJson.version;
 const BEACON_ENDPOINT = "https://beacon.kjschultz.com/ping";
 const CLIENT_ID = "PrismPlayer";
@@ -373,6 +400,7 @@ const defaultSettings: AppSettings = {
   sidebarPlaylistLimit: 8,
   analyticsEnabled: false,
   analyticsPromptDismissed: false,
+  updateDismissedVersion: "",
   coverWashEnabled: true,
   lowPerformanceMode: false,
   radioStationUrl: "",
@@ -518,6 +546,7 @@ function loadStoredSettings(): AppSettings {
       sidebarPlaylistLimit: clampNumber(Number(parsed.sidebarPlaylistLimit ?? defaultSettings.sidebarPlaylistLimit), 3, 20),
       analyticsEnabled: Boolean(parsed.analyticsEnabled),
       analyticsPromptDismissed: Boolean(parsed.analyticsPromptDismissed),
+      updateDismissedVersion: typeof parsed.updateDismissedVersion === "string" ? parsed.updateDismissedVersion : "",
       coverWashEnabled: parsed.coverWashEnabled ?? defaultSettings.coverWashEnabled,
       lowPerformanceMode: Boolean(parsed.lowPerformanceMode),
       radioStationUrl: activeStation || radioStationUrls[0] || defaultSettings.radioStationUrl,
@@ -1538,6 +1567,7 @@ export function App() {
   const [config, setConfig] = useState<NavidromeConfig | null>(() => loadStoredConfig());
   const [form, setForm] = useState<NavidromeConfig>(() => loadStoredConfig() ?? emptyConfig);
   const [appSettings, setAppSettings] = useState<AppSettings>(() => loadStoredSettings());
+  const [availableUpdate, setAvailableUpdate] = useState<AvailableUpdate | null>(null);
   const [status, setStatus] = useState<ConnectionStatus>("idle");
   const [statusMessage, setStatusMessage] = useState("Add a Navidrome server to start syncing.");
   const [libraryStatus, setLibraryStatus] = useState<LibraryStatus>(() => (loadStoredConfig() ? "loading" : "idle"));
@@ -3100,6 +3130,30 @@ export function App() {
   }, [currentIndex, position, queue]);
 
   useEffect(() => {
+    const controller = new AbortController();
+
+    void fetch(PRISM_LATEST_RELEASE_API, {
+      headers: { Accept: "application/vnd.github+json" },
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error("Unable to check for updates.");
+        return (await response.json()) as { tag_name?: string; html_url?: string; draft?: boolean; prerelease?: boolean };
+      })
+      .then((release) => {
+        const version = release.tag_name?.replace(/^v/, "") ?? "";
+        if (!release.draft && !release.prerelease && version && isVersionNewer(version, packageJson.version)) {
+          setAvailableUpdate({ version, releaseUrl: release.html_url || PRISM_RELEASES_URL });
+        }
+      })
+      .catch((error: unknown) => {
+        if (!(error instanceof DOMException && error.name === "AbortError")) setAvailableUpdate(null);
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
     if (!config || !currentTrack || !isPlaying) return;
 
     const duration = playerDuration || currentTrack.duration || 0;
@@ -3456,6 +3510,12 @@ export function App() {
         <div className="workspace-viewport">
           {!appSettings.analyticsEnabled && !appSettings.analyticsPromptDismissed ? (
             <AnalyticsBanner onEnable={() => setAnalyticsConsent(true)} onDismiss={dismissAnalyticsPrompt} />
+          ) : null}
+          {availableUpdate && appSettings.updateDismissedVersion !== availableUpdate.version ? (
+            <UpdateBanner
+              update={availableUpdate}
+              onDismiss={() => updateAppSettings({ ...appSettings, updateDismissedVersion: availableUpdate.version })}
+            />
           ) : null}
 
           {activeView === "settings" ? (
@@ -4671,6 +4731,28 @@ function AnalyticsBanner({
         <button className="connect-button compact-button" type="button" onClick={onEnable}>
           Enable
         </button>
+      </div>
+    </section>
+  );
+}
+
+function UpdateBanner({ update, onDismiss }: { update: AvailableUpdate; onDismiss: () => void }) {
+  return (
+    <section className="analytics-banner update-banner" aria-label="Prism update available">
+      <div className="analytics-banner-icon" aria-hidden="true">
+        <Download size={18} />
+      </div>
+      <div>
+        <strong>Prism {update.version} is available</strong>
+        <p>You’re using {packageJson.version}. Visit the release page to download the latest build.</p>
+      </div>
+      <div className="analytics-banner-actions">
+        <button className="secondary-button compact-button" type="button" onClick={onDismiss}>
+          Not Now
+        </button>
+        <a className="connect-button compact-button" href={update.releaseUrl} target="_blank" rel="noreferrer">
+          View Release
+        </a>
       </div>
     </section>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5103,7 +5103,7 @@ function SettingsView({
             </button>}
             <p className={`settings-note update-check-status ${updateCheckStatus === "error" ? "bad" : ""}`}>
               {updateCheckStatus === "checking" ? "Checking GitHub releases…" : null}
-              {updateCheckStatus === "up-to-date" ? "You’re on the latest released version." : null}
+              {updateCheckStatus === "up-to-date" ? "You’re up to date." : null}
               {updateCheckStatus === "available" && availableUpdate ? `Prism v${availableUpdate.version} is ready to download.` : null}
               {updateCheckStatus === "error" ? "Couldn’t check for updates right now. Try again shortly." : null}
               {updateCheckStatus === "idle" ? "Check GitHub Releases for the latest Prism build." : null}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,9 +9,12 @@ import {
   CheckCircle2,
   Disc3,
   Download,
+  ExternalLink,
+  Github,
   History,
   Heart,
   Home,
+  Info,
   Library,
   ListMusic,
   Loader2,
@@ -23,6 +26,7 @@ import {
   Play,
   Plus,
   RadioTower,
+  RefreshCw,
   Repeat,
   Repeat1,
   Search,
@@ -35,6 +39,7 @@ import {
   Square,
   Trash2,
   Menu,
+  MessageCircle,
   UserRound,
   Volume2,
   Waves,
@@ -44,7 +49,7 @@ import packageJson from "../package.json";
 
 type LibraryViewMode = "overview" | "albums" | "artists" | "playlists" | "recentlyAdded" | "recentlyPlayed" | "favorites";
 type View = LibraryViewMode | "radio" | "search" | "settings";
-type SettingsTab = "connection" | "library" | "appearance" | "radio" | "privacy" | "advanced";
+type SettingsTab = "connection" | "library" | "appearance" | "radio" | "privacy" | "about" | "advanced";
 type ConnectionStatus = "idle" | "checking" | "connected" | "error";
 type LibraryStatus = "idle" | "loading" | "ready" | "error";
 type AlbumViewMode = "art" | "list";
@@ -354,6 +359,8 @@ const INSTALL_ID_KEY = "prism-player.installId";
 const ANALYTICS_LAST_PING_KEY = "prism-player.analyticsLastPing";
 const PRISM_RELEASES_URL = "https://github.com/kylejschultz/prism-player/releases/latest";
 const PRISM_LATEST_RELEASE_API = "https://api.github.com/repos/kylejschultz/prism-player/releases/latest";
+const PRISM_REPOSITORY_URL = "https://github.com/kylejschultz/prism-player";
+const PRISM_DISCORD_URL = "https://discord.gg/aDEBQq3XtN";
 const APP_VERSION = packageJson.version;
 const BEACON_ENDPOINT = "https://beacon.kjschultz.com/ping";
 const CLIENT_ID = "PrismPlayer";
@@ -458,6 +465,7 @@ function getSettingsTabLabel(tab: SettingsTab) {
     appearance: "Appearance",
     radio: "Radio",
     privacy: "Privacy",
+    about: "About",
     advanced: "Advanced",
   };
 
@@ -1568,6 +1576,7 @@ export function App() {
   const [form, setForm] = useState<NavidromeConfig>(() => loadStoredConfig() ?? emptyConfig);
   const [appSettings, setAppSettings] = useState<AppSettings>(() => loadStoredSettings());
   const [availableUpdate, setAvailableUpdate] = useState<AvailableUpdate | null>(null);
+  const [updateCheckStatus, setUpdateCheckStatus] = useState<"idle" | "checking" | "up-to-date" | "available" | "error">("idle");
   const [status, setStatus] = useState<ConnectionStatus>("idle");
   const [statusMessage, setStatusMessage] = useState("Add a Navidrome server to start syncing.");
   const [libraryStatus, setLibraryStatus] = useState<LibraryStatus>(() => (loadStoredConfig() ? "loading" : "idle"));
@@ -3129,26 +3138,37 @@ export function App() {
     };
   }, [currentIndex, position, queue]);
 
+  async function checkForUpdates(signal?: AbortSignal) {
+    setUpdateCheckStatus("checking");
+
+    try {
+      const response = await fetch(PRISM_LATEST_RELEASE_API, {
+      headers: { Accept: "application/vnd.github+json" },
+        signal,
+      });
+      if (!response.ok) throw new Error("Unable to check for updates.");
+
+      const release = (await response.json()) as { tag_name?: string; html_url?: string; draft?: boolean; prerelease?: boolean };
+      const version = release.tag_name?.replace(/^v/, "") ?? "";
+      if (!release.draft && !release.prerelease && version && isVersionNewer(version, packageJson.version)) {
+        setAvailableUpdate({ version, releaseUrl: release.html_url || PRISM_RELEASES_URL });
+        setUpdateCheckStatus("available");
+        return;
+      }
+
+      setAvailableUpdate(null);
+      setUpdateCheckStatus("up-to-date");
+    } catch (error) {
+      if (!(error instanceof DOMException && error.name === "AbortError")) {
+        setAvailableUpdate(null);
+        setUpdateCheckStatus("error");
+      }
+    }
+  }
+
   useEffect(() => {
     const controller = new AbortController();
-
-    void fetch(PRISM_LATEST_RELEASE_API, {
-      headers: { Accept: "application/vnd.github+json" },
-      signal: controller.signal,
-    })
-      .then(async (response) => {
-        if (!response.ok) throw new Error("Unable to check for updates.");
-        return (await response.json()) as { tag_name?: string; html_url?: string; draft?: boolean; prerelease?: boolean };
-      })
-      .then((release) => {
-        const version = release.tag_name?.replace(/^v/, "") ?? "";
-        if (!release.draft && !release.prerelease && version && isVersionNewer(version, packageJson.version)) {
-          setAvailableUpdate({ version, releaseUrl: release.html_url || PRISM_RELEASES_URL });
-        }
-      })
-      .catch((error: unknown) => {
-        if (!(error instanceof DOMException && error.name === "AbortError")) setAvailableUpdate(null);
-      });
+    void checkForUpdates(controller.signal);
 
     return () => controller.abort();
   }, []);
@@ -3534,6 +3554,9 @@ export function App() {
               resetAppSettings={resetAppSettings}
               setAlbumViewMode={setAlbumViewMode}
               setArtistViewMode={setArtistViewMode}
+              availableUpdate={availableUpdate}
+              updateCheckStatus={updateCheckStatus}
+              onCheckForUpdates={() => void checkForUpdates()}
               onSave={saveConnection}
               onReset={resetConnection}
             />
@@ -4773,6 +4796,9 @@ function SettingsView({
   resetAppSettings,
   setAlbumViewMode,
   setArtistViewMode,
+  availableUpdate,
+  updateCheckStatus,
+  onCheckForUpdates,
   onSave,
   onReset,
 }: {
@@ -4790,6 +4816,9 @@ function SettingsView({
   resetAppSettings: () => void;
   setAlbumViewMode: (mode: AlbumViewMode) => void;
   setArtistViewMode: (mode: ArtistViewMode) => void;
+  availableUpdate: AvailableUpdate | null;
+  updateCheckStatus: "idle" | "checking" | "up-to-date" | "available" | "error";
+  onCheckForUpdates: () => void;
   onSave: (event?: FormEvent<HTMLFormElement>) => Promise<void>;
   onReset: () => void;
 }) {
@@ -4823,6 +4852,7 @@ function SettingsView({
           { id: "appearance", label: "Appearance", icon: <Waves size={15} /> },
           { id: "radio", label: "Radio", icon: <RadioTower size={15} /> },
           { id: "privacy", label: "Privacy", icon: <CheckCircle2 size={15} /> },
+          { id: "about", label: "About", icon: <Info size={15} /> },
           { id: "advanced", label: "Advanced", icon: <Settings size={15} /> },
         ].map((tab) => (
           <button
@@ -5046,6 +5076,42 @@ function SettingsView({
         <p className="settings-note">
           Sends a periodic Beacon ping with app version, install id, platform, channel, dev/release flag, and aggregate artist, album, and song counts. No account or playback data is sent.
         </p>
+      </section> : null}
+
+      {activeTab === "about" ? <section className="settings-panel about-panel">
+        <div className="panel-heading">
+          <div>
+            <p className="eyebrow">Prism Player</p>
+            <h3>About</h3>
+          </div>
+          <Info size={18} />
+        </div>
+        <div className="about-version-row">
+          <div>
+            <span className="settings-label">Installed version</span>
+            <strong>v{APP_VERSION}</strong>
+          </div>
+          <button className="secondary-button compact-button" type="button" onClick={onCheckForUpdates} disabled={updateCheckStatus === "checking"}>
+            {updateCheckStatus === "checking" ? <Loader2 size={15} className="spin" /> : <RefreshCw size={15} />}
+            Check for updates
+          </button>
+        </div>
+        <p className={`settings-note update-check-status ${updateCheckStatus === "error" ? "bad" : ""}`}>
+          {updateCheckStatus === "checking" ? "Checking GitHub releases…" : null}
+          {updateCheckStatus === "up-to-date" ? "You’re on the latest released version." : null}
+          {updateCheckStatus === "available" && availableUpdate ? `Prism v${availableUpdate.version} is ready to download.` : null}
+          {updateCheckStatus === "error" ? "Couldn’t check for updates right now. Try again shortly." : null}
+          {updateCheckStatus === "idle" ? "Check GitHub Releases for the latest Prism build." : null}
+        </p>
+        {availableUpdate ? <a className="connect-button compact-button about-update-link" href={availableUpdate.releaseUrl} target="_blank" rel="noreferrer">
+          <Download size={15} />
+          View v{availableUpdate.version}
+        </a> : null}
+        <div className="about-links" aria-label="Prism links">
+          <a href={PRISM_REPOSITORY_URL} target="_blank" rel="noreferrer"><Github size={16} /> GitHub <ExternalLink size={13} /></a>
+          <a href={PRISM_RELEASES_URL} target="_blank" rel="noreferrer"><Download size={16} /> Releases <ExternalLink size={13} /></a>
+          <a href={PRISM_DISCORD_URL} target="_blank" rel="noreferrer"><MessageCircle size={16} /> Discord <ExternalLink size={13} /></a>
+        </div>
       </section> : null}
 
       {activeTab === "advanced" ? <section className="settings-panel">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties, FormEvent, MouseEvent, PointerEvent as ReactPointer
 import {
   AlertCircle,
   CalendarDays,
+  Code2,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
@@ -10,7 +11,6 @@ import {
   Disc3,
   Download,
   ExternalLink,
-  Github,
   History,
   Heart,
   Home,
@@ -5108,7 +5108,7 @@ function SettingsView({
           View v{availableUpdate.version}
         </a> : null}
         <div className="about-links" aria-label="Prism links">
-          <a href={PRISM_REPOSITORY_URL} target="_blank" rel="noreferrer"><Github size={16} /> GitHub <ExternalLink size={13} /></a>
+          <a href={PRISM_REPOSITORY_URL} target="_blank" rel="noreferrer"><Code2 size={16} /> GitHub <ExternalLink size={13} /></a>
           <a href={PRISM_RELEASES_URL} target="_blank" rel="noreferrer"><Download size={16} /> Releases <ExternalLink size={13} /></a>
           <a href={PRISM_DISCORD_URL} target="_blank" rel="noreferrer"><MessageCircle size={16} /> Discord <ExternalLink size={13} /></a>
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5091,8 +5091,8 @@ function SettingsView({
           <div className="about-version-details">
             <span className="settings-label">Installed version</span>
             <strong>v{APP_VERSION}</strong>
+            <span className="about-commit-sha" title={`Commit ${APP_COMMIT_SHA}`}>SHA {APP_COMMIT_SHA}</span>
           </div>
-          <span className="about-commit-sha" title={`Commit ${APP_COMMIT_SHA}`}>SHA {APP_COMMIT_SHA}</span>
           <div className="about-update-action">
             {availableUpdate ? <a className="connect-button compact-button" href={availableUpdate.releaseUrl} target="_blank" rel="noreferrer">
               <Download size={15} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5087,26 +5087,27 @@ function SettingsView({
           <Info size={18} />
         </div>
         <div className="about-version-row">
-          <div>
+          <div className="about-version-details">
             <span className="settings-label">Installed version</span>
             <strong>v{APP_VERSION}</strong>
           </div>
-          <button className="secondary-button compact-button" type="button" onClick={onCheckForUpdates} disabled={updateCheckStatus === "checking"}>
-            {updateCheckStatus === "checking" ? <Loader2 size={15} className="spin" /> : <RefreshCw size={15} />}
-            Check for updates
-          </button>
+          <div className="about-update-action">
+            {availableUpdate ? <a className="connect-button compact-button" href={availableUpdate.releaseUrl} target="_blank" rel="noreferrer">
+              <Download size={15} />
+              Update available
+            </a> : <button className="secondary-button compact-button" type="button" onClick={onCheckForUpdates} disabled={updateCheckStatus === "checking"}>
+              {updateCheckStatus === "checking" ? <Loader2 size={15} className="spin" /> : <RefreshCw size={15} />}
+              Check for updates
+            </button>}
+            <p className={`settings-note update-check-status ${updateCheckStatus === "error" ? "bad" : ""}`}>
+              {updateCheckStatus === "checking" ? "Checking GitHub releases…" : null}
+              {updateCheckStatus === "up-to-date" ? "You’re on the latest released version." : null}
+              {updateCheckStatus === "available" && availableUpdate ? `Prism v${availableUpdate.version} is ready to download.` : null}
+              {updateCheckStatus === "error" ? "Couldn’t check for updates right now. Try again shortly." : null}
+              {updateCheckStatus === "idle" ? "Check GitHub Releases for the latest Prism build." : null}
+            </p>
+          </div>
         </div>
-        <p className={`settings-note update-check-status ${updateCheckStatus === "error" ? "bad" : ""}`}>
-          {updateCheckStatus === "checking" ? "Checking GitHub releases…" : null}
-          {updateCheckStatus === "up-to-date" ? "You’re on the latest released version." : null}
-          {updateCheckStatus === "available" && availableUpdate ? `Prism v${availableUpdate.version} is ready to download.` : null}
-          {updateCheckStatus === "error" ? "Couldn’t check for updates right now. Try again shortly." : null}
-          {updateCheckStatus === "idle" ? "Check GitHub Releases for the latest Prism build." : null}
-        </p>
-        {availableUpdate ? <a className="connect-button compact-button about-update-link" href={availableUpdate.releaseUrl} target="_blank" rel="noreferrer">
-          <Download size={15} />
-          View v{availableUpdate.version}
-        </a> : null}
         <div className="about-links" aria-label="Prism links">
           <a href={PRISM_REPOSITORY_URL} target="_blank" rel="noreferrer"><Code2 size={16} /> GitHub <ExternalLink size={13} /></a>
           <a href={PRISM_RELEASES_URL} target="_blank" rel="noreferrer"><Download size={16} /> Releases <ExternalLink size={13} /></a>

--- a/src/styles.css
+++ b/src/styles.css
@@ -2000,6 +2000,15 @@ button.similar-chip:hover,
   gap: 3px;
 }
 
+.about-commit-sha {
+  color: rgba(244, 241, 236, 0.48);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
 .settings-label {
   color: rgba(244, 241, 236, 0.56);
   font-size: 11px;
@@ -2024,7 +2033,7 @@ button.similar-chip:hover,
 
 .about-update-action {
   display: grid;
-  justify-items: center;
+  justify-items: end;
   gap: 6px;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -2022,9 +2022,11 @@ button.similar-chip:hover,
 }
 
 .update-check-status {
-  min-height: 16px;
   margin: 0;
-  text-align: center;
+  color: rgba(244, 241, 236, 0.58);
+  font-size: 12px;
+  line-height: 1.25;
+  text-align: right;
 }
 
 .update-check-status.bad {
@@ -2034,7 +2036,7 @@ button.similar-chip:hover,
 .about-update-action {
   display: grid;
   justify-items: end;
-  gap: 6px;
+  gap: 5px;
 }
 
 .about-links {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1985,9 +1985,9 @@ button.similar-chip:hover,
 }
 
 .about-version-row {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
   gap: 14px;
   padding: 14px;
   border: 1px solid rgba(242, 217, 133, 0.16);
@@ -1995,7 +1995,7 @@ button.similar-chip:hover,
   background: linear-gradient(135deg, rgba(242, 217, 133, 0.11), rgba(255, 255, 255, 0.035));
 }
 
-.about-version-row > div {
+.about-version-details {
   display: grid;
   gap: 3px;
 }
@@ -2013,16 +2013,19 @@ button.similar-chip:hover,
 }
 
 .update-check-status {
-  min-height: 18px;
-  margin: -4px 0 0;
+  min-height: 16px;
+  margin: 0;
+  text-align: center;
 }
 
 .update-check-status.bad {
   color: #ffad9f;
 }
 
-.about-update-link {
-  justify-self: start;
+.about-update-action {
+  display: grid;
+  justify-items: center;
+  gap: 6px;
 }
 
 .about-links {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1980,6 +1980,80 @@ button.similar-chip:hover,
   padding-top: 18px;
 }
 
+.about-panel {
+  align-content: start;
+}
+
+.about-version-row {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px;
+  border: 1px solid rgba(242, 217, 133, 0.16);
+  border-radius: 10px;
+  background: linear-gradient(135deg, rgba(242, 217, 133, 0.11), rgba(255, 255, 255, 0.035));
+}
+
+.about-version-row > div {
+  display: grid;
+  gap: 3px;
+}
+
+.settings-label {
+  color: rgba(244, 241, 236, 0.56);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.about-version-row strong {
+  font-size: 20px;
+  letter-spacing: -0.02em;
+}
+
+.update-check-status {
+  min-height: 18px;
+  margin: -4px 0 0;
+}
+
+.update-check-status.bad {
+  color: #ffad9f;
+}
+
+.about-update-link {
+  justify-self: start;
+}
+
+.about-links {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.about-links a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 38px;
+  padding: 0 10px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.045);
+  color: rgba(244, 241, 236, 0.78);
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.about-links a:hover,
+.about-links a:focus-visible {
+  border-color: rgba(242, 217, 133, 0.3);
+  background: rgba(242, 217, 133, 0.12);
+  color: #f8df91;
+}
+
 .settings-form label,
 .settings-panel label {
   display: grid;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1986,7 +1986,7 @@ button.similar-chip:hover,
 
 .about-version-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   align-items: center;
   gap: 14px;
   padding: 14px;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_COMMIT_SHA__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,20 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { execSync } from "node:child_process";
+
+const commitSha = (() => {
+  try {
+    return execSync("git rev-parse --short=7 HEAD", { encoding: "utf8" }).trim();
+  } catch {
+    return "local";
+  }
+})();
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_COMMIT_SHA__: JSON.stringify(commitSha),
+  },
   clearScreen: false,
   server: {
     host: "127.0.0.1",


### PR DESCRIPTION
Closes #25

## Summary

- check GitHub Releases automatically and show a dismissible update-available banner
- add Settings → About with installed version, a manual update check, release/repository/Discord links, and a direct link when an update is available

## Validation

- `npm run test`
- `npm run build`