### PR TITLE
fix: unify playback control hierarchy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,6 @@ import {
   Plus,
   RadioTower,
   Repeat,
-  Repeat1,
   Search,
   Send,
   Settings,
@@ -3698,7 +3697,7 @@ export function App() {
                   <SkipForward size={16} />
                 </button>
                 <button
-                  className={repeatMode !== "off" ? "active" : ""}
+                  className={`repeat-button ${repeatMode !== "off" ? "active" : ""} ${repeatMode === "one" ? "repeat-one" : ""}`}
                   type="button"
                   aria-label={`Repeat ${repeatMode}`}
                   aria-pressed={repeatMode !== "off"}
@@ -3706,7 +3705,8 @@ export function App() {
                   disabled={!queue.length}
                   title={repeatMode === "off" ? "Repeat off" : repeatMode === "all" ? "Repeat all" : "Repeat one"}
                 >
-                  {repeatMode === "one" ? <Repeat1 size={15} /> : <Repeat size={15} />}
+                  <Repeat size={15} />
+                  {repeatMode === "one" ? <span className="repeat-one-indicator" aria-hidden="true">1</span> : null}
                 </button>
               </>
             )}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3234,9 +3234,9 @@ button.similar-chip:hover,
   grid-template-columns: minmax(260px, 0.72fr) minmax(500px, 1.35fr) minmax(260px, 0.68fr);
   grid-template-areas: "now center actions";
   align-items: center;
-  gap: 16px;
-  height: 94px;
-  padding: 10px 18px 12px;
+  gap: 14px;
+  height: 84px;
+  padding: 8px 18px 10px;
   border-top: 1px solid rgba(255, 255, 255, 0.1);
   background:
     linear-gradient(90deg, rgba(240, 210, 123, 0.08), transparent 28%, rgba(63, 145, 133, 0.07)),
@@ -3251,9 +3251,9 @@ button.similar-chip:hover,
 .now-playing {
   grid-area: now;
   display: grid;
-  grid-template-columns: 66px minmax(0, 1fr);
+  grid-template-columns: 56px minmax(0, 1fr);
   align-items: center;
-  gap: 18px;
+  gap: 12px;
   min-width: 0;
 }
 
@@ -3263,8 +3263,8 @@ button.similar-chip:hover,
 
 .player-cover {
   display: block;
-  width: 66px;
-  height: 66px;
+  width: 56px;
+  height: 56px;
   border-radius: 8px;
   object-fit: cover;
   background: rgba(255, 255, 255, 0.06);
@@ -3334,11 +3334,11 @@ button.similar-chip:hover,
 .player-center {
   grid-area: center;
   display: grid;
-  grid-template-rows: 38px 22px;
+  grid-template-rows: 42px 18px;
   justify-items: center;
   align-items: center;
   align-self: center;
-  gap: 6px;
+  gap: 3px;
   min-width: 0;
 }
 
@@ -3347,15 +3347,15 @@ button.similar-chip:hover,
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 8px;
-  height: 38px;
+  gap: 7px;
+  height: 42px;
 }
 
 .transport button {
   display: grid;
   place-items: center;
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.1);
 }
@@ -3366,9 +3366,9 @@ button.similar-chip:hover,
 }
 
 .transport .play-button {
-  width: 38px;
-  height: 38px;
-  border-radius: 10px;
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
   background: #f2d985;
   color: #16120a;
 }
@@ -3385,7 +3385,7 @@ button.similar-chip:hover,
 }
 
 .radio-transport {
-  gap: 10px;
+  gap: 7px;
 }
 
 .radio-transport button {
@@ -3400,8 +3400,29 @@ button.similar-chip:hover,
 .radio-transport .play-button {
   width: 42px;
   height: 42px;
-  border-radius: 10px;
+  border-radius: 999px;
   color: #16120a;
+}
+
+.repeat-button {
+  position: relative;
+}
+
+.repeat-one-indicator {
+  position: absolute;
+  right: -5px;
+  bottom: -5px;
+  display: grid;
+  place-items: center;
+  width: 13px;
+  height: 13px;
+  border: 2px solid rgba(7, 7, 7, 0.9);
+  border-radius: 999px;
+  background: #f8df91;
+  color: #241d0c;
+  font-size: 8px;
+  font-weight: 800;
+  line-height: 1;
 }
 
 .radio-control-popover {


### PR DESCRIPTION
Closes #48

## Summary

- give local and Subwave the same 42px circular primary playback control
- reduce the player bar height and art footprint for a more compact, breathable footer
- move the repeat-one indicator into a high-contrast badge beside the icon

## Validation

- `npm run test`
- `npm run build`