### PR TITLE
ci: split manual macOS and Windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
         description: Published release tag to build and announce, for example v0.1.0
         required: false
         type: string
+      source_ref:
+        description: Git ref to build for a manual test artifact (does not publish a release asset)
+        required: false
+        type: string
       announce_only:
         description: Send the Discord announcement without rebuilding release artifacts
         required: false
@@ -41,12 +45,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.source_ref || github.ref }}
 
       - name: Resolve artifact name
         id: artifact
         env:
-          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref || inputs.source_ref }}
         run: |
           if [[ -n "$RELEASE_TAG" ]]; then
             suffix="$RELEASE_TAG"
@@ -98,13 +102,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.source_ref || github.ref }}
 
       - name: Resolve artifact name
         id: artifact
         shell: pwsh
         env:
-          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref || inputs.source_ref }}
         run: |
           if ($env:RELEASE_TAG) {
             $suffix = $env:RELEASE_TAG

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,15 @@ on:
         required: false
         default: false
         type: boolean
+      platform:
+        description: Build target for manual test builds
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - macos
+          - windows
 
 permissions:
   contents: write
@@ -25,7 +34,7 @@ concurrency:
 jobs:
   macos:
     name: macOS DMG
-    if: inputs.announce_only != true
+    if: inputs.announce_only != true && (github.event_name == 'release' || inputs.platform != 'windows')
     runs-on: macos-latest
 
     steps:
@@ -82,7 +91,7 @@ jobs:
 
   windows:
     name: Windows installer
-    if: inputs.announce_only != true
+    if: inputs.announce_only != true && (github.event_name == 'release' || inputs.platform != 'macos')
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
## Summary
- add a platform selector to manual Build workflow runs
- allow a manual test build to check out a separate source ref without attaching assets to a GitHub release
- keep published releases building both macOS and Windows

## Validation
- workflow YAML parsed successfully
- git diff --check passed