### PR TITLE
feat: brand macOS installer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,11 +56,19 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
       - name: Install frontend dependencies
         run: npm ci --no-audit --no-fund
 
-      - name: Build macOS app
-        run: npm run tauri:build
+      - name: Install macOS packaging dependency
+        run: python -m pip install --disable-pip-version-check dmgbuild
+
+      - name: Build macOS installer
+        run: npm run tauri:build:installer
 
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,8 @@ npm test
 Build the macOS DMG:
 
 ```sh
-npm run tauri:build
+python3 -m pip install dmgbuild
+npm run tauri:build:installer
 ```
 
 ## Repository workflow

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build"
+    "tauri:build": "tauri build",
+    "tauri:build:app": "tauri build --bundles app",
+    "tauri:build:installer": "npm run tauri:build:app && ./scripts/package-macos-installer.sh"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.8.0",

--- a/scripts/dmgbuild-settings.py
+++ b/scripts/dmgbuild-settings.py
@@ -1,7 +1,7 @@
 import os
 
 application = defines["application"]
-background = os.path.join(defines["assets"], "background.png")
+background = os.path.join(defines["assets"], "background-v2.png")
 
 files = [application]
 symlinks = {"Applications": "/Applications"}

--- a/scripts/dmgbuild-settings.py
+++ b/scripts/dmgbuild-settings.py
@@ -1,0 +1,21 @@
+import os
+
+application = defines["application"]
+background = os.path.join(defines["assets"], "background.png")
+
+files = [application]
+symlinks = {"Applications": "/Applications"}
+format = "UDZO"
+window_rect = ((120, 120), (1000, 620))
+icon_size = 112
+text_size = 13
+default_view = "icon-view"
+show_toolbar = False
+show_status_bar = False
+show_sidebar = False
+show_pathbar = False
+show_tab_view = False
+icon_locations = {
+    "Prism Player.app": (265, 315),
+    "Applications": (735, 315),
+}

--- a/scripts/macos-installer-background.svg
+++ b/scripts/macos-installer-background.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="620" viewBox="0 0 1000 620">
+  <defs>
+    <linearGradient id="base" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b0b13"/>
+      <stop offset=".52" stop-color="#151223"/>
+      <stop offset="1" stop-color="#080a11"/>
+    </linearGradient>
+    <linearGradient id="swoop" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ff825f"/>
+      <stop offset=".36" stop-color="#f5d36f"/>
+      <stop offset=".68" stop-color="#84d4bd"/>
+      <stop offset="1" stop-color="#8476e9"/>
+    </linearGradient>
+    <filter id="blur"><feGaussianBlur stdDeviation="26"/></filter>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%"><feGaussianBlur stdDeviation="6" result="blur"/><feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  </defs>
+  <rect width="1000" height="620" fill="url(#base)"/>
+  <path d="M-100 532 C166 398 260 654 494 472 S866 251 1110 344" fill="none" stroke="url(#swoop)" stroke-width="58" opacity=".22" filter="url(#blur)"/>
+  <path d="M-90 539 C166 406 264 644 500 469 S860 266 1090 344" fill="none" stroke="url(#swoop)" stroke-width="2" opacity=".78"/>
+  <circle cx="148" cy="103" r="180" fill="#806ee8" opacity=".11" filter="url(#blur)"/>
+  <circle cx="879" cy="128" r="150" fill="#f3cb70" opacity=".08" filter="url(#blur)"/>
+  <text x="500" y="100" text-anchor="middle" fill="#fbfaf7" font-family="SF Pro Display, Helvetica Neue, Arial, sans-serif" font-size="34" font-weight="700" letter-spacing="1">Prism Player</text>
+  <text x="500" y="132" text-anchor="middle" fill="#b9b5ca" font-family="SF Pro Text, Helvetica Neue, Arial, sans-serif" font-size="16" letter-spacing=".4">Your music, in focus.</text>
+  <path d="M396 318 H604" stroke="#f6d87b" stroke-width="4" stroke-linecap="round" filter="url(#glow)"/>
+  <path d="M574 291 L604 318 L574 345" fill="none" stroke="#f6d87b" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" filter="url(#glow)"/>
+  <text x="500" y="394" text-anchor="middle" fill="#f7f4ed" font-family="SF Pro Text, Helvetica Neue, Arial, sans-serif" font-size="17" font-weight="600" letter-spacing=".2">Drag Prism Player to Applications</text>
+  <text x="500" y="423" text-anchor="middle" fill="#aaa5b8" font-family="SF Pro Text, Helvetica Neue, Arial, sans-serif" font-size="13">Then launch it from your Applications folder</text>
+  <path d="M430 476 H570" stroke="#fff" stroke-opacity=".16"/>
+  <text x="500" y="510" text-anchor="middle" fill="#aaa5b8" font-family="SF Pro Text, Helvetica Neue, Arial, sans-serif" font-size="12" letter-spacing="1.8">PRISM PLAYER FOR MACOS</text>
+</svg>

--- a/scripts/macos-installer-background.svg
+++ b/scripts/macos-installer-background.svg
@@ -21,8 +21,7 @@
   <circle cx="879" cy="128" r="150" fill="#f3cb70" opacity=".08" filter="url(#blur)"/>
   <text x="500" y="100" text-anchor="middle" fill="#fbfaf7" font-family="SF Pro Display, Helvetica Neue, Arial, sans-serif" font-size="34" font-weight="700" letter-spacing="1">Prism Player</text>
   <text x="500" y="132" text-anchor="middle" fill="#b9b5ca" font-family="SF Pro Text, Helvetica Neue, Arial, sans-serif" font-size="16" letter-spacing=".4">Your music, in focus.</text>
-  <path d="M396 318 H604" stroke="#f6d87b" stroke-width="4" stroke-linecap="round" filter="url(#glow)"/>
-  <path d="M574 291 L604 318 L574 345" fill="none" stroke="#f6d87b" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" filter="url(#glow)"/>
+  <path d="M440 318 H560 M530 288 L560 318 L530 348" fill="none" stroke="#f6d87b" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" filter="url(#glow)"/>
   <text x="500" y="394" text-anchor="middle" fill="#f7f4ed" font-family="SF Pro Text, Helvetica Neue, Arial, sans-serif" font-size="17" font-weight="600" letter-spacing=".2">Drag Prism Player to Applications</text>
   <text x="500" y="423" text-anchor="middle" fill="#aaa5b8" font-family="SF Pro Text, Helvetica Neue, Arial, sans-serif" font-size="13">Then launch it from your Applications folder</text>
   <path d="M430 476 H570" stroke="#fff" stroke-opacity=".16"/>

--- a/scripts/package-macos-installer.sh
+++ b/scripts/package-macos-installer.sh
@@ -1,0 +1,25 @@
+#!/bin/zsh
+set -euo pipefail
+
+ROOT_DIR="${0:A:h:h}"
+APP_PATH="${1:-$ROOT_DIR/src-tauri/target/release/bundle/macos/Prism Player.app}"
+OUTPUT_DIR="$ROOT_DIR/src-tauri/target/release/bundle/dmg"
+VOLUME_NAME="Prism Player"
+DMG_PATH="$OUTPUT_DIR/Prism.Player.dmg"
+ASSETS_DIR="$(mktemp -d /tmp/prism-player-dmg-assets.XXXXXX)"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+cleanup() { rm -rf "$ASSETS_DIR"; }
+trap cleanup EXIT
+
+if [[ ! -d "$APP_PATH" ]]; then
+  print -u2 "Expected app bundle at: $APP_PATH"
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+sips -s format png "$ROOT_DIR/scripts/macos-installer-background.svg" --out "$ASSETS_DIR/background.png" >/dev/null
+rm -f "$DMG_PATH"
+"$PYTHON_BIN" -m dmgbuild -s "$ROOT_DIR/scripts/dmgbuild-settings.py" \
+  -D "application=$APP_PATH" -D "assets=$ASSETS_DIR" "$VOLUME_NAME" "$DMG_PATH"
+print "$DMG_PATH"

--- a/scripts/package-macos-installer.sh
+++ b/scripts/package-macos-installer.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="${0:A:h:h}"
 APP_PATH="${1:-$ROOT_DIR/src-tauri/target/release/bundle/macos/Prism Player.app}"
 OUTPUT_DIR="$ROOT_DIR/src-tauri/target/release/bundle/dmg"
-VOLUME_NAME="Prism Player"
+VOLUME_NAME="${VOLUME_NAME:-Prism Player}"
 DMG_PATH="$OUTPUT_DIR/Prism.Player.dmg"
 ASSETS_DIR="$(mktemp -d /tmp/prism-player-dmg-assets.XXXXXX)"
 PYTHON_BIN="${PYTHON_BIN:-python3}"
@@ -18,7 +18,7 @@ if [[ ! -d "$APP_PATH" ]]; then
 fi
 
 mkdir -p "$OUTPUT_DIR"
-sips -s format png "$ROOT_DIR/scripts/macos-installer-background.svg" --out "$ASSETS_DIR/background.png" >/dev/null
+sips -s format png "$ROOT_DIR/scripts/macos-installer-background.svg" --out "$ASSETS_DIR/background-v2.png" >/dev/null
 rm -f "$DMG_PATH"
 "$PYTHON_BIN" -m dmgbuild -s "$ROOT_DIR/scripts/dmgbuild-settings.py" \
   -D "application=$APP_PATH" -D "assets=$ASSETS_DIR" "$VOLUME_NAME" "$DMG_PATH"


### PR DESCRIPTION
## Summary

- add the branded macOS DMG layout as the default packaging path
- use a centered right-arrow between the app and Applications icons
- keep DMG assets and build settings reproducible through the packaging script

## Validation

- rebuilt the DMG with the project `dmgbuild` environment
- mounted the generated DMG and verified Finder’s app-to-Applications layout
- checked the final diff for whitespace errors

## Notes

- macOS Finder may cache a mounted volume background by volume/asset identity; verification used distinct preview volume names while the committed default remains `Prism Player`.
