### PR TITLE
fix: Let library tracks be selected before playback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "prism-player",
       "version": "0.2.0",
       "dependencies": {
+        "@radix-ui/react-dropdown-menu": "^2.1.24",
         "@tauri-apps/api": "^2.8.0",
         "lucide-react": "^1.30.0",
         "react": "^19.2.8",
@@ -155,6 +156,44 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -246,6 +285,538 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
+      "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+      "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-rect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.2.3",
@@ -777,7 +1348,7 @@
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -787,7 +1358,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -1102,6 +1673,18 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1144,7 +1727,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1181,6 +1764,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1453,6 +2042,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/glob-parent": {
@@ -2130,6 +2728,75 @@
         "react": "^19.2.8"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
@@ -2232,6 +2899,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2291,6 +2964,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "tauri:build:installer": "npm run tauri:build:app && ./scripts/package-macos-installer.sh"
   },
   "dependencies": {
+    "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@tauri-apps/api": "^2.8.0",
     "lucide-react": "^1.30.0",
     "react": "^19.2.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -217,6 +217,7 @@ type BrowserSnapshot = {
 
 type SongContextMenuState = {
   song: Song;
+  songs: Song[];
   x: number;
   y: number;
 } | null;
@@ -2400,14 +2401,14 @@ export function App() {
     setDetailSelection({ type: "playlist", data: updatedPlaylist });
   }
 
-  async function addSongToPlaylist(playlist: Playlist, song: Song) {
+  async function addSongsToSelectedPlaylist(playlist: Playlist, songs: Song[]) {
     if (!config || playlistAddStatus === "saving") return;
 
     setPlaylistAddStatus("saving");
-    setPlaylistAddMessage(`Adding to ${playlist.name}...`);
+    setPlaylistAddMessage(`Adding ${songs.length === 1 ? "song" : `${songs.length} songs`} to ${playlist.name}...`);
 
     try {
-      await addSongsToPlaylist(config, playlist.id, [song]);
+      await addSongsToPlaylist(config, playlist.id, songs);
       const [nextLibrary, updatedPlaylist] = await Promise.all([
         fetchLibrary(config),
         detailSelection?.type === "playlist" && detailSelection.data.id === playlist.id
@@ -2471,12 +2472,12 @@ export function App() {
     }
   }
 
-  function openSongContextMenu(event: MouseEvent<HTMLElement>, song: Song) {
+  function openSongContextMenu(event: MouseEvent<HTMLElement>, song: Song, selectedSongs: Song[] = [song]) {
     event.preventDefault();
     setLibraryContextMenu(null);
     setPlaylistAddStatus("idle");
     setPlaylistAddMessage("");
-    setSongContextMenu({ song, x: event.clientX, y: event.clientY });
+    setSongContextMenu({ song, songs: selectedSongs.some((selectedSong) => selectedSong.id === song.id) ? selectedSongs : [song], x: event.clientX, y: event.clientY });
   }
 
   function openLibraryContextMenu(event: MouseEvent<HTMLElement>) {
@@ -4183,7 +4184,7 @@ export function App() {
           playlists={libraryData.playlists}
           status={playlistAddStatus}
           message={playlistAddMessage}
-          onAdd={(playlist) => void addSongToPlaylist(playlist, songContextMenu.song)}
+          onAdd={(playlist) => void addSongsToSelectedPlaylist(playlist, songContextMenu.songs)}
           onPlayNow={(song) => {
             playSong(song);
             setSongContextMenu(null);
@@ -5844,7 +5845,7 @@ function LibraryView({
   searchResults: SearchResults;
   searchStatus: "idle" | "searching" | "error";
   setPlaylistCreatorOpen: (open: boolean) => void;
-  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song) => void;
+  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
   onSelectLibraryView: (view: View) => void;
   detailSelection: DetailSelection;
   detailStatus: "idle" | "loading" | "error";
@@ -6250,7 +6251,7 @@ function FavoritesView({
   onPlayArtist: (artist: Artist | ArtistDetail) => void;
   onPlaySong: (song: Song) => void;
   onQueueSong: (song: Song) => void;
-  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song) => void;
+  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
   const totalFavorites = favorites.artists.length + favorites.albums.length + favorites.songs.length;
 
@@ -6361,7 +6362,7 @@ function SearchResultsView({
   onPlayArtist: (artist: Artist | ArtistDetail) => void;
   onPlaySong: (song: Song) => void;
   onQueueSong: (song: Song) => void;
-  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song) => void;
+  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
   const trimmedQuery = query.trim();
   const totalResults = results.artists.length + results.albums.length + results.songs.length + results.playlists.length;
@@ -6513,20 +6514,31 @@ function SearchSongList({
   onToggleFavorite: (kind: FavoriteKind, id: string, favorite: boolean) => void;
   onPlaySong: (song: Song) => void;
   onQueueSong: (song: Song) => void;
-  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song) => void;
+  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
+  const { isSelected, selectTrack, selectedSongs } = useTrackSelection(songs);
+
   return (
     <div className="search-song-list">
-      {songs.map((song) => (
+      {songs.map((song, index) => (
         <div
-          className={`search-song-row ${currentTrack?.id === song.id ? "active" : ""}`}
+          className={`search-song-row ${currentTrack?.id === song.id ? "active" : ""} ${isSelected(index) ? "selected" : ""}`}
           key={song.id}
-          onContextMenu={(event) => onSongContextMenu(event, song)}
+          onContextMenu={(event) => onSongContextMenu(event, song, selectedSongs)}
+          onClick={(event) => selectTrack(event, index)}
         >
-          <button className="track-play" type="button" onClick={() => onPlaySong(song)} aria-label={`Play ${song.title}`}>
+          <button
+            className="track-play"
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onPlaySong(song);
+            }}
+            aria-label={`Play ${song.title}`}
+          >
             <Play size={14} fill="currentColor" />
           </button>
-          <button className="search-song-main" type="button" onClick={() => onPlaySong(song)}>
+          <button className="search-song-main" type="button" aria-label={`Select ${song.title}`}>
             <strong>{song.title}</strong>
             <small>{[song.artist, song.album].filter(Boolean).join(" - ") || "Song"}</small>
           </button>
@@ -6537,7 +6549,15 @@ function SearchSongList({
             label={song.title}
             onToggle={(favorite) => onToggleFavorite("song", song.id, favorite)}
           />
-          <button className="track-queue" type="button" onClick={() => onQueueSong(song)} aria-label={`Queue ${song.title}`}>
+          <button
+            className="track-queue"
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onQueueSong(song);
+            }}
+            aria-label={`Queue ${song.title}`}
+          >
             <Plus size={14} />
           </button>
         </div>
@@ -6575,6 +6595,8 @@ function ListeningHistoryView({
   onPlaySong: (song: Song) => void;
   onClear: () => void;
 }) {
+  const { isSelected, selectTrack } = useTrackSelection(history.map((entry) => entry.song));
+
   if (!history.length) {
     return <EmptyPanel icon={<History size={20} />} text="Play a song for a little while and it will appear here. Your history stays on this device." />;
   }
@@ -6588,12 +6610,25 @@ function ListeningHistoryView({
         </button>
       </div>
       <div className="listening-history-list">
-        {history.map((entry) => (
-          <div className="track-row history-track-row" key={entry.id}>
-            <button className="track-play" type="button" onClick={() => onPlaySong(entry.song)} aria-label={`Play ${entry.song.title}`}>
+        {history.map((entry, index) => (
+          <div
+            className={`track-row history-track-row ${isSelected(index) ? "selected" : ""}`}
+            key={entry.id}
+            onClick={(event) => selectTrack(event, index)}
+            onDoubleClick={() => onPlaySong(entry.song)}
+          >
+            <button
+              className="track-play"
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                onPlaySong(entry.song);
+              }}
+              aria-label={`Play ${entry.song.title}`}
+            >
               <Play size={14} fill="currentColor" />
             </button>
-            <button className="track-name history-track-name" type="button" onClick={() => onPlaySong(entry.song)}>
+            <button className="track-name history-track-name" type="button" aria-label={`Select ${entry.song.title}`}>
               <strong>{entry.song.title}</strong>
             </button>
             <span className="history-track-artist">{entry.song.artist || "Unknown artist"}</span>
@@ -6603,6 +6638,50 @@ function ListeningHistoryView({
       </div>
     </div>
   );
+}
+
+function useTrackSelection(songs: Song[]) {
+  const [selectedIndexes, setSelectedIndexes] = useState<Set<number>>(() => new Set());
+  const [selectionAnchor, setSelectionAnchor] = useState<number | null>(null);
+
+  useEffect(() => {
+    setSelectedIndexes((current) => {
+      const next = new Set([...current].filter((index) => index < songs.length));
+      return next.size === current.size ? current : next;
+    });
+  }, [songs]);
+
+  const selectTrack = (event: MouseEvent<HTMLElement>, index: number) => {
+    const song = songs[index];
+    if (!song) return;
+
+    if (event.shiftKey && selectionAnchor != null) {
+      const rangeStart = Math.min(selectionAnchor, index);
+      const rangeEnd = Math.max(selectionAnchor, index);
+      setSelectedIndexes(new Set(songs.slice(rangeStart, rangeEnd + 1).map((_, rangeIndex) => rangeStart + rangeIndex)));
+      return;
+    }
+
+    if (event.metaKey || event.ctrlKey) {
+      setSelectedIndexes((current) => {
+        const next = new Set(current);
+        if (next.has(index)) next.delete(index);
+        else next.add(index);
+        return next;
+      });
+      setSelectionAnchor(index);
+      return;
+    }
+
+    setSelectedIndexes(new Set([index]));
+    setSelectionAnchor(index);
+  };
+
+  return {
+    isSelected: (index: number) => selectedIndexes.has(index),
+    selectedSongs: songs.filter((_, index) => selectedIndexes.has(index)),
+    selectTrack,
+  };
 }
 
 function AlbumBrowser({
@@ -7280,7 +7359,7 @@ function PlaylistDetailPanel({
   onReorderPlaylist: (playlist: PlaylistDetail, songs: Song[]) => Promise<void>;
   onReplaceQueue: (songs: Song[], startIndex?: number) => void;
   onQueueSong: (song: Song) => void;
-  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song) => void;
+  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
   const songs = playlist.entry ?? [];
   const playlistCover =
@@ -7596,7 +7675,7 @@ function DetailPanel({
   onReorderPlaylist: (playlist: PlaylistDetail, songs: Song[]) => Promise<void>;
   onReplaceQueue: (songs: Song[], startIndex?: number) => void;
   onQueueSong: (song: Song) => void;
-  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song) => void;
+  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
   if (detailStatus === "loading" || detailStatus === "error") {
     return (
@@ -7806,8 +7885,10 @@ function TrackList({
   emptyText?: string;
   onPlaySong: (song: Song) => void;
   onQueueSong: (song: Song) => void;
-  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song) => void;
+  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
+  const { isSelected, selectTrack, selectedSongs } = useTrackSelection(songs);
+
   if (!songs.length) {
     return <EmptyPanel icon={<Music2 size={20} />} text={emptyText} />;
   }
@@ -7825,18 +7906,25 @@ function TrackList({
               <small>{group.songs.length} tracks</small>
             </div>
           ) : null}
-          {group.songs.map((song, index) => (
+          {group.songs.map((song, index) => {
+            const songIndex = songs.findIndex((listSong) => listSong.id === song.id);
+
+            return (
             <div
-              className={`track-row ${currentTrack?.id === song.id ? "active" : ""}`}
+              className={`track-row ${currentTrack?.id === song.id ? "active" : ""} ${isSelected(songIndex) ? "selected" : ""}`}
               key={song.id}
-              onContextMenu={(event) => onSongContextMenu(event, song)}
+              onContextMenu={(event) => onSongContextMenu(event, song, selectedSongs)}
+              onClick={(event) => selectTrack(event, songIndex)}
               onDoubleClick={() => onPlaySong(song)}
             >
               <button
                 className="track-play"
                 type="button"
                 aria-label={`Play ${song.title}`}
-                onClick={() => onPlaySong(song)}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onPlaySong(song);
+                }}
                 onDoubleClick={(event) => event.stopPropagation()}
               >
                 <Play size={14} fill="currentColor" />
@@ -7845,8 +7933,7 @@ function TrackList({
               <button
                 className="track-name"
                 type="button"
-                onClick={() => onPlaySong(song)}
-                onDoubleClick={(event) => event.stopPropagation()}
+                aria-label={`Select ${song.title}`}
               >
                 {song.title}
               </button>
@@ -7862,13 +7949,17 @@ function TrackList({
                 className="track-queue"
                 type="button"
                 aria-label={`Queue ${song.title}`}
-                onClick={() => onQueueSong(song)}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onQueueSong(song);
+                }}
                 onDoubleClick={(event) => event.stopPropagation()}
               >
                 <Plus size={14} />
               </button>
             </div>
-          ))}
+            );
+          })}
         </div>
       ))}
     </div>
@@ -7908,8 +7999,9 @@ function EditablePlaylistTrackList({
   onToggleFavorite: (kind: FavoriteKind, id: string, favorite: boolean) => void;
   onPlaySong: (song: Song) => void;
   onQueueSong: (song: Song) => void;
-  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song) => void;
+  onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
+  const { isSelected, selectTrack, selectedSongs } = useTrackSelection(songs);
   const displayedSongs = useMemo(() => {
     if (draggedIndex == null || dragOverIndex == null || draggedIndex === dragOverIndex) {
       return songs.map((song, index) => ({ song, index }));
@@ -7934,9 +8026,10 @@ function EditablePlaylistTrackList({
       <div className="track-list">
         {displayedSongs.map(({ song, index }, displayIndex) => (
           <div
-            className={`track-row playlist-track-row ${currentTrack?.id === song.id ? "active" : ""} ${index === draggedIndex ? "dragging" : ""}`}
+            className={`track-row playlist-track-row ${currentTrack?.id === song.id ? "active" : ""} ${isSelected(index) ? "selected" : ""} ${index === draggedIndex ? "dragging" : ""}`}
             key={`${song.id}-${index}`}
-            onContextMenu={(event) => onSongContextMenu(event, song)}
+            onContextMenu={(event) => onSongContextMenu(event, song, selectedSongs)}
+            onClick={(event) => selectTrack(event, index)}
             onDoubleClick={() => onPlaySong(song)}
             onDragOver={(event) => {
               event.preventDefault();
@@ -7950,6 +8043,7 @@ function EditablePlaylistTrackList({
               aria-label={`Drag ${song.title} to reorder`}
               draggable
               disabled={busy}
+              onClick={(event) => event.stopPropagation()}
               onDragStart={(event) => {
                 event.dataTransfer.effectAllowed = "move";
                 event.dataTransfer.setData("text/plain", String(index));
@@ -7967,8 +8061,7 @@ function EditablePlaylistTrackList({
             <button
               className="track-name"
               type="button"
-              onClick={() => onPlaySong(song)}
-              onDoubleClick={(event) => event.stopPropagation()}
+              aria-label={`Select ${song.title}`}
             >
               {song.title}
             </button>
@@ -7984,7 +8077,10 @@ function EditablePlaylistTrackList({
               className="track-queue"
               type="button"
               aria-label={`Queue ${song.title}`}
-              onClick={() => onQueueSong(song)}
+              onClick={(event) => {
+                event.stopPropagation();
+                onQueueSong(song);
+              }}
               onDoubleClick={(event) => event.stopPropagation()}
             >
               <Plus size={14} />
@@ -7994,7 +8090,10 @@ function EditablePlaylistTrackList({
               type="button"
               aria-label={`Remove ${song.title} from playlist`}
               disabled={busy}
-              onClick={() => onRemoveTrack(index)}
+              onClick={(event) => {
+                event.stopPropagation();
+                onRemoveTrack(index);
+              }}
               onDoubleClick={(event) => event.stopPropagation()}
             >
               <Trash2 size={14} />
@@ -8197,12 +8296,12 @@ function SongPlaylistMenu({
         top: Math.min(menu.y, window.innerHeight - 440),
       }}
       role="menu"
-      aria-label={`Song actions for ${menu.song.title}`}
+      aria-label={`${menu.songs.length === 1 ? "Song" : `${menu.songs.length} selected songs`} actions for ${menu.song.title}`}
     >
       <div className="song-context-heading">
         <div>
-          <p className="eyebrow">Song</p>
-          <strong>{menu.song.title}</strong>
+          <p className="eyebrow">{menu.songs.length === 1 ? "Song" : `${menu.songs.length} songs selected`}</p>
+          <strong>{menu.songs.length === 1 ? menu.song.title : `${menu.song.title} and ${menu.songs.length - 1} more`}</strong>
         </div>
       </div>
       {message ? <p className={`song-context-status ${status === "error" ? "bad" : ""}`}>{message}</p> : null}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type { CSSProperties, FormEvent, KeyboardEvent as ReactKeyboardEvent, MouseEvent, PointerEvent as ReactPointerEvent, ReactNode } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import {
@@ -57,6 +58,10 @@ type ArtistViewMode = "art" | "list";
 type RepeatMode = "off" | "all" | "one";
 type RightPanelTab = "queue" | "nowPlaying" | "lyrics";
 type LyricsStatus = "idle" | "loading" | "ready" | "empty" | "error";
+
+function ViewportModal({ children, className = "" }: { children: ReactNode; className?: string }) {
+  return createPortal(<div className={`modal-backdrop ${className}`.trim()}>{children}</div>, document.body);
+}
 
 type AvailableUpdate = {
   version: string;
@@ -4199,7 +4204,7 @@ export function App() {
         />
       ) : null}
       {playlistCreatorOpen ? (
-        <div className="modal-backdrop">
+        <ViewportModal>
           <section className="playlist-modal" role="dialog" aria-modal="true" aria-labelledby="playlist-create-title">
             <div className="modal-heading">
               <div>
@@ -4226,7 +4231,7 @@ export function App() {
               onCancel={closePlaylistCreator}
             />
           </section>
-        </div>
+        </ViewportModal>
       ) : null}
       {songContextMenu ? (
         <SongPlaylistMenu
@@ -4323,7 +4328,7 @@ export function App() {
         />
       ) : null}
       {playlistDeleteTarget ? (
-        <div className="modal-backdrop confirm-backdrop">
+        <ViewportModal className="confirm-backdrop">
           <section className="playlist-modal confirm-modal" role="alertdialog" aria-modal="true" aria-labelledby="context-playlist-delete-title">
             <div className="confirm-icon" aria-hidden="true">
               <Trash2 size={22} />
@@ -4356,7 +4361,7 @@ export function App() {
               <p className={`confirm-status ${playlistDeleteStatus === "error" ? "bad" : ""}`}>{playlistDeleteMessage}</p>
             ) : null}
           </section>
-        </div>
+        </ViewportModal>
       ) : null}
     </main>
   );
@@ -5426,7 +5431,7 @@ function FirstRunWizard({
   onClose: () => void;
 }) {
   return (
-    <div className="modal-backdrop">
+    <ViewportModal>
       <section className="setup-modal" role="dialog" aria-modal="true" aria-labelledby="setup-title">
         <button className="icon-button close-button" type="button" aria-label="Close setup" onClick={onClose}>
           <X size={18} />
@@ -5470,7 +5475,7 @@ function FirstRunWizard({
 
         <p className={`wizard-status ${status === "error" ? "bad" : ""}`}>{statusMessage}</p>
       </section>
-    </div>
+    </ViewportModal>
   );
 }
 
@@ -7603,7 +7608,7 @@ function PlaylistDetailPanel({
         </div>
       </div>
       {editing ? (
-        <div className="modal-backdrop">
+        <ViewportModal>
           <section className="playlist-modal" role="dialog" aria-modal="true" aria-labelledby="playlist-edit-title">
             <div className="modal-heading">
               <div>
@@ -7656,10 +7661,10 @@ function PlaylistDetailPanel({
               </div>
             </form>
           </section>
-        </div>
+        </ViewportModal>
       ) : null}
       {confirmingDelete ? (
-        <div className="modal-backdrop confirm-backdrop">
+        <ViewportModal className="confirm-backdrop">
           <section className="playlist-modal confirm-modal" role="alertdialog" aria-modal="true" aria-labelledby="playlist-delete-title">
             <div className="confirm-icon" aria-hidden="true">
               <Trash2 size={22} />
@@ -7680,7 +7685,7 @@ function PlaylistDetailPanel({
             </div>
             {message ? <p className={`confirm-status ${status === "error" ? "bad" : ""}`}>{message}</p> : null}
           </section>
-        </div>
+        </ViewportModal>
       ) : null}
       <EditablePlaylistTrackList
         songs={draftSongs}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2424,6 +2424,33 @@ export function App() {
       setPlaylistAddStatus("idle");
       setPlaylistAddMessage("");
       setSongContextMenu(null);
+      setLibraryContextMenu(null);
+    } catch (error) {
+      setPlaylistAddStatus("error");
+      setPlaylistAddMessage(getErrorMessage(error));
+    }
+  }
+
+  async function addAlbumToPlaylist(playlist: Playlist, album: Album) {
+    if (!config) return;
+
+    try {
+      const detail = await fetchAlbumDetail(config, album.id);
+      await addSongsToSelectedPlaylist(playlist, sortAlbumSongs(detail.song ?? []));
+    } catch (error) {
+      setPlaylistAddStatus("error");
+      setPlaylistAddMessage(getErrorMessage(error));
+    }
+  }
+
+  async function addArtistToPlaylist(playlist: Playlist, artist: Artist) {
+    if (!config) return;
+
+    try {
+      const detail = await fetchArtistDetail(config, artist.id);
+      const albums = detail.album ?? [];
+      const albumDetails = await Promise.all(albums.slice(0, 50).map((album) => fetchAlbumDetail(config, album.id)));
+      await addSongsToSelectedPlaylist(playlist, albumDetails.flatMap((album) => album.song ?? []));
     } catch (error) {
       setPlaylistAddStatus("error");
       setPlaylistAddMessage(getErrorMessage(error));
@@ -4263,6 +4290,10 @@ export function App() {
             void toggleFavorite(kind, id, favorite);
             setLibraryContextMenu(null);
           }}
+          playlists={libraryData.playlists}
+          status={playlistAddStatus}
+          onAddAlbum={(playlist, album) => void addAlbumToPlaylist(playlist, album)}
+          onAddArtist={(playlist, artist) => void addArtistToPlaylist(playlist, artist)}
           onClose={() => setLibraryContextMenu(null)}
         />
       ) : null}
@@ -8168,6 +8199,10 @@ function LibraryContextMenu({
   onEditPlaylist,
   onDeletePlaylist,
   onToggleFavorite,
+  playlists,
+  status,
+  onAddAlbum,
+  onAddArtist,
   onClose,
 }: {
   menu: Exclude<LibraryContextMenuState, null>;
@@ -8182,10 +8217,15 @@ function LibraryContextMenu({
   onEditPlaylist: (playlist: Playlist) => void;
   onDeletePlaylist: (playlist: Playlist) => void;
   onToggleFavorite: (kind: FavoriteKind, id: string, favorite: boolean) => void;
+  playlists: Playlist[];
+  status: "idle" | "saving" | "error";
+  onAddAlbum: (playlist: Playlist, album: Album) => void;
+  onAddArtist: (playlist: Playlist, artist: Artist) => void;
   onClose: () => void;
 }) {
   const title = menu.item.name;
   const menuLabel = menu.type === "album" ? "Album" : menu.type === "artist" ? "Artist" : "Playlist";
+  const sortedPlaylists = [...playlists].sort((a, b) => a.name.localeCompare(b.name));
 
   return (
     <DropdownMenu.Root open onOpenChange={(open) => !open && onClose()} modal={false}>
@@ -8224,6 +8264,7 @@ function LibraryContextMenu({
               )}
               {favoriteIds.albums.has(menu.item.id) ? "Remove Favorite" : "Add Favorite"}
             </button>
+            <AddToPlaylistSubmenu playlists={sortedPlaylists} status={status} onAdd={(playlist) => onAddAlbum(playlist, menu.item)} />
           </>
         ) : null}
         {menu.type === "artist" ? (
@@ -8249,6 +8290,7 @@ function LibraryContextMenu({
               )}
               {favoriteIds.artists.has(menu.item.id) ? "Remove Favorite" : "Add Favorite"}
             </button>
+            <AddToPlaylistSubmenu playlists={sortedPlaylists} status={status} onAdd={(playlist) => onAddArtist(playlist, menu.item)} />
           </>
         ) : null}
         {menu.type === "playlist" ? (
@@ -8275,6 +8317,45 @@ function LibraryContextMenu({
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>
+  );
+}
+
+function AddToPlaylistSubmenu({
+  playlists,
+  status,
+  onAdd,
+}: {
+  playlists: Playlist[];
+  status: "idle" | "saving" | "error";
+  onAdd: (playlist: Playlist) => void;
+}) {
+  return (
+    <DropdownMenu.Sub>
+      <DropdownMenu.SubTrigger className="song-context-action song-context-submenu-trigger">
+        <ListMusic size={15} />
+        <span>Add to playlist</span>
+        <ChevronRight size={15} />
+      </DropdownMenu.SubTrigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.SubContent className="song-context-menu song-context-flyout" sideOffset={4} collisionPadding={12} aria-label="Choose playlist">
+          {playlists.length ? (
+            <div className="song-context-list">
+              {playlists.map((playlist) => (
+                <button type="button" role="menuitem" key={playlist.id} onClick={() => onAdd(playlist)} disabled={status === "saving"}>
+                  <ListMusic size={15} />
+                  <span>
+                    <strong>{playlist.name}</strong>
+                    <small>{getPlaylistMeta(playlist)}</small>
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <p className="song-context-empty">Create a playlist first.</p>
+          )}
+        </DropdownMenu.SubContent>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Sub>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { CSSProperties, FormEvent, MouseEvent, PointerEvent as ReactPointerEvent, ReactNode } from "react";
+import type { CSSProperties, FormEvent, KeyboardEvent as ReactKeyboardEvent, MouseEvent, PointerEvent as ReactPointerEvent, ReactNode } from "react";
 import {
   AlertCircle,
   CalendarDays,
@@ -6516,10 +6516,10 @@ function SearchSongList({
   onQueueSong: (song: Song) => void;
   onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
-  const { isSelected, selectTrack, selectedSongs } = useTrackSelection(songs);
+  const { isSelected, selectTrack, selectedSongs, handleKeyDown } = useTrackSelection(songs);
 
   return (
-    <div className="search-song-list">
+    <div className="search-song-list" tabIndex={0} onKeyDown={handleKeyDown} aria-label="Songs">
       {songs.map((song, index) => (
         <div
           className={`search-song-row ${currentTrack?.id === song.id ? "active" : ""} ${isSelected(index) ? "selected" : ""}`}
@@ -6595,7 +6595,7 @@ function ListeningHistoryView({
   onPlaySong: (song: Song) => void;
   onClear: () => void;
 }) {
-  const { isSelected, selectTrack } = useTrackSelection(history.map((entry) => entry.song));
+  const { isSelected, selectTrack, handleKeyDown } = useTrackSelection(history.map((entry) => entry.song));
 
   if (!history.length) {
     return <EmptyPanel icon={<History size={20} />} text="Play a song for a little while and it will appear here. Your history stays on this device." />;
@@ -6609,7 +6609,7 @@ function ListeningHistoryView({
           Clear history
         </button>
       </div>
-      <div className="listening-history-list">
+      <div className="listening-history-list" tabIndex={0} onKeyDown={handleKeyDown} aria-label="Recently played songs">
         {history.map((entry, index) => (
           <div
             className={`track-row history-track-row ${isSelected(index) ? "selected" : ""}`}
@@ -6677,10 +6677,19 @@ function useTrackSelection(songs: Song[]) {
     setSelectionAnchor(index);
   };
 
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "a") {
+      event.preventDefault();
+      setSelectedIndexes(new Set(songs.map((_, index) => index)));
+      setSelectionAnchor(songs.length ? 0 : null);
+    }
+  };
+
   return {
     isSelected: (index: number) => selectedIndexes.has(index),
     selectedSongs: songs.filter((_, index) => selectedIndexes.has(index)),
     selectTrack,
+    handleKeyDown,
   };
 }
 
@@ -7887,7 +7896,7 @@ function TrackList({
   onQueueSong: (song: Song) => void;
   onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
-  const { isSelected, selectTrack, selectedSongs } = useTrackSelection(songs);
+  const { isSelected, selectTrack, selectedSongs, handleKeyDown } = useTrackSelection(songs);
 
   if (!songs.length) {
     return <EmptyPanel icon={<Music2 size={20} />} text={emptyText} />;
@@ -7897,7 +7906,7 @@ function TrackList({
   const showDiscHeaders = discGroups.length > 1;
 
   return (
-    <div className="track-list">
+    <div className="track-list" tabIndex={0} onKeyDown={handleKeyDown} aria-label="Album tracks">
       {discGroups.map((group) => (
         <div className="disc-group" key={group.discNumber ?? "unknown-disc"}>
           {showDiscHeaders ? (
@@ -8001,7 +8010,7 @@ function EditablePlaylistTrackList({
   onQueueSong: (song: Song) => void;
   onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
-  const { isSelected, selectTrack, selectedSongs } = useTrackSelection(songs);
+  const { isSelected, selectTrack, selectedSongs, handleKeyDown } = useTrackSelection(songs);
   const displayedSongs = useMemo(() => {
     if (draggedIndex == null || dragOverIndex == null || draggedIndex === dragOverIndex) {
       return songs.map((song, index) => ({ song, index }));
@@ -8023,7 +8032,7 @@ function EditablePlaylistTrackList({
         <p className="eyebrow">Tracks</p>
         {message ? <span className={busy ? "" : "bad"}>{message}</span> : null}
       </div>
-      <div className="track-list">
+      <div className="track-list" tabIndex={0} onKeyDown={handleKeyDown} aria-label="Playlist tracks">
         {displayedSongs.map(({ song, index }, displayIndex) => (
           <div
             className={`track-row playlist-track-row ${currentTrack?.id === song.id ? "active" : ""} ${isSelected(index) ? "selected" : ""} ${index === draggedIndex ? "dragging" : ""}`}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8296,6 +8296,8 @@ function SongPlaylistMenu({
   onToggleFavorite: (favorite: boolean) => void;
 }) {
   const sortedPlaylists = [...playlists].sort((a, b) => a.name.localeCompare(b.name));
+  const [playlistFlyoutOpen, setPlaylistFlyoutOpen] = useState(false);
+  const flyoutOpensLeft = menu.x > window.innerWidth - 560;
 
   return (
     <div
@@ -8342,28 +8344,44 @@ function SongPlaylistMenu({
           {isFavorite ? "Remove Favorite" : "Add Favorite"}
         </button>
       </div>
-      <div className="song-context-subheading">Add to playlist</div>
-      {sortedPlaylists.length ? (
-        <div className="song-context-list">
-          {sortedPlaylists.map((playlist) => (
-            <button
-              type="button"
-              role="menuitem"
-              key={playlist.id}
-              onClick={() => onAdd(playlist)}
-              disabled={status === "saving"}
-            >
-              <ListMusic size={15} />
-              <span>
-                <strong>{playlist.name}</strong>
-                <small>{getPlaylistMeta(playlist)}</small>
-              </span>
-            </button>
-          ))}
-        </div>
-      ) : (
-        <p className="song-context-empty">Create a playlist first.</p>
-      )}
+      <div className="song-context-submenu" onMouseEnter={() => setPlaylistFlyoutOpen(true)} onMouseLeave={() => setPlaylistFlyoutOpen(false)}>
+        <button
+          className="song-context-action song-context-submenu-trigger"
+          type="button"
+          onClick={() => setPlaylistFlyoutOpen((open) => !open)}
+          aria-expanded={playlistFlyoutOpen}
+          aria-haspopup="menu"
+        >
+          <ListMusic size={15} />
+          <span>Add to playlist</span>
+          <ChevronRight size={15} />
+        </button>
+        {playlistFlyoutOpen ? (
+          <div className={`song-context-flyout ${flyoutOpensLeft ? "opens-left" : ""}`} role="menu" aria-label="Choose playlist">
+            {sortedPlaylists.length ? (
+              <div className="song-context-list">
+                {sortedPlaylists.map((playlist) => (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    key={playlist.id}
+                    onClick={() => onAdd(playlist)}
+                    disabled={status === "saving"}
+                  >
+                    <ListMusic size={15} />
+                    <span>
+                      <strong>{playlist.name}</strong>
+                      <small>{getPlaylistMeta(playlist)}</small>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <p className="song-context-empty">Create a playlist first.</p>
+            )}
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1695,6 +1695,7 @@ export function App() {
   const [playlistDescription, setPlaylistDescription] = useState("");
   const [playlistPublic, setPlaylistPublic] = useState(false);
   const [playlistFromQueue, setPlaylistFromQueue] = useState(true);
+  const [playlistSeedSongs, setPlaylistSeedSongs] = useState<Song[] | null>(null);
   const [playlistCreateStatus, setPlaylistCreateStatus] = useState<"idle" | "saving" | "error">("idle");
   const [playlistCreateMessage, setPlaylistCreateMessage] = useState("");
   const [songContextMenu, setSongContextMenu] = useState<SongContextMenuState>(null);
@@ -2292,7 +2293,7 @@ export function App() {
       return;
     }
 
-    const seedSongs = playlistFromQueue ? queue : [];
+    const seedSongs = playlistSeedSongs ?? (playlistFromQueue ? queue : []);
     const trimmedDescription = playlistDescription.trim();
     setPlaylistCreateStatus("saving");
     setPlaylistCreateMessage("Creating playlist...");
@@ -2323,6 +2324,7 @@ export function App() {
       setPlaylistName("");
       setPlaylistDescription("");
       setPlaylistPublic(false);
+      setPlaylistSeedSongs(null);
       setPlaylistCreatorOpen(false);
       setPlaylistCreateStatus("idle");
       setPlaylistCreateMessage("");
@@ -2923,6 +2925,18 @@ export function App() {
     setPlaylistName("");
     setPlaylistDescription("");
     setPlaylistPublic(false);
+    setPlaylistSeedSongs(null);
+  }
+
+  function createPlaylistFromSongs(name: string, songs: Song[]) {
+    setPlaylistName(name);
+    setPlaylistDescription("");
+    setPlaylistPublic(false);
+    setPlaylistFromQueue(false);
+    setPlaylistSeedSongs(songs);
+    setSongContextMenu(null);
+    setLibraryContextMenu(null);
+    setPlaylistCreatorOpen(true);
   }
 
   function togglePlayback() {
@@ -4244,6 +4258,7 @@ export function App() {
           isFavorite={favoriteIds.songs.has(songContextMenu.song.id)}
           favoriteBusy={favoriteBusyKey === `song:${songContextMenu.song.id}`}
           onToggleFavorite={(favorite) => void toggleFavorite("song", songContextMenu.song.id, favorite)}
+          onCreatePlaylist={() => createPlaylistFromSongs(songContextMenu.song.title, songContextMenu.songs)}
           onClose={() => setSongContextMenu(null)}
         />
       ) : null}
@@ -4294,6 +4309,16 @@ export function App() {
           status={playlistAddStatus}
           onAddAlbum={(playlist, album) => void addAlbumToPlaylist(playlist, album)}
           onAddArtist={(playlist, artist) => void addArtistToPlaylist(playlist, artist)}
+          onCreateAlbumPlaylist={(album) => {
+            if (!config) return;
+            void fetchAlbumDetail(config, album.id).then((detail) => createPlaylistFromSongs(album.name, sortAlbumSongs(detail.song ?? [])));
+          }}
+          onCreateArtistPlaylist={(artist) => {
+            if (!config) return;
+            void fetchArtistDetail(config, artist.id)
+              .then((detail) => Promise.all((detail.album ?? []).slice(0, 50).map((album) => fetchAlbumDetail(config, album.id))))
+              .then((albums) => createPlaylistFromSongs(artist.name, albums.flatMap((album) => album.song ?? [])));
+          }}
           onClose={() => setLibraryContextMenu(null)}
         />
       ) : null}
@@ -8203,6 +8228,8 @@ function LibraryContextMenu({
   status,
   onAddAlbum,
   onAddArtist,
+  onCreateAlbumPlaylist,
+  onCreateArtistPlaylist,
   onClose,
 }: {
   menu: Exclude<LibraryContextMenuState, null>;
@@ -8221,6 +8248,8 @@ function LibraryContextMenu({
   status: "idle" | "saving" | "error";
   onAddAlbum: (playlist: Playlist, album: Album) => void;
   onAddArtist: (playlist: Playlist, artist: Artist) => void;
+  onCreateAlbumPlaylist: (album: Album) => void;
+  onCreateArtistPlaylist: (artist: Artist) => void;
   onClose: () => void;
 }) {
   const title = menu.item.name;
@@ -8264,7 +8293,7 @@ function LibraryContextMenu({
               )}
               {favoriteIds.albums.has(menu.item.id) ? "Remove Favorite" : "Add Favorite"}
             </button>
-            <AddToPlaylistSubmenu playlists={sortedPlaylists} status={status} onAdd={(playlist) => onAddAlbum(playlist, menu.item)} />
+            <AddToPlaylistSubmenu playlists={sortedPlaylists} status={status} onAdd={(playlist) => onAddAlbum(playlist, menu.item)} onCreateNew={() => onCreateAlbumPlaylist(menu.item)} />
           </>
         ) : null}
         {menu.type === "artist" ? (
@@ -8290,7 +8319,7 @@ function LibraryContextMenu({
               )}
               {favoriteIds.artists.has(menu.item.id) ? "Remove Favorite" : "Add Favorite"}
             </button>
-            <AddToPlaylistSubmenu playlists={sortedPlaylists} status={status} onAdd={(playlist) => onAddArtist(playlist, menu.item)} />
+            <AddToPlaylistSubmenu playlists={sortedPlaylists} status={status} onAdd={(playlist) => onAddArtist(playlist, menu.item)} onCreateNew={() => onCreateArtistPlaylist(menu.item)} />
           </>
         ) : null}
         {menu.type === "playlist" ? (
@@ -8324,10 +8353,12 @@ function AddToPlaylistSubmenu({
   playlists,
   status,
   onAdd,
+  onCreateNew,
 }: {
   playlists: Playlist[];
   status: "idle" | "saving" | "error";
   onAdd: (playlist: Playlist) => void;
+  onCreateNew: () => void;
 }) {
   return (
     <DropdownMenu.Sub>
@@ -8353,6 +8384,10 @@ function AddToPlaylistSubmenu({
           ) : (
             <p className="song-context-empty">Create a playlist first.</p>
           )}
+          <button className="song-context-action new-playlist-action" type="button" onClick={onCreateNew}>
+            <Plus size={15} />
+            Add to new playlist
+          </button>
         </DropdownMenu.SubContent>
       </DropdownMenu.Portal>
     </DropdownMenu.Sub>
@@ -8373,6 +8408,7 @@ function SongPlaylistMenu({
   isFavorite,
   favoriteBusy,
   onToggleFavorite,
+  onCreatePlaylist,
   onClose,
 }: {
   menu: Exclude<SongContextMenuState, null>;
@@ -8388,6 +8424,7 @@ function SongPlaylistMenu({
   isFavorite: boolean;
   favoriteBusy: boolean;
   onToggleFavorite: (favorite: boolean) => void;
+  onCreatePlaylist: () => void;
   onClose: () => void;
 }) {
   const sortedPlaylists = [...playlists].sort((a, b) => a.name.localeCompare(b.name));
@@ -8463,6 +8500,10 @@ function SongPlaylistMenu({
             ) : (
               <p className="song-context-empty">Create a playlist first.</p>
             )}
+            <button className="song-context-action new-playlist-action" type="button" onClick={onCreatePlaylist}>
+              <Plus size={15} />
+              Add to new playlist
+            </button>
           </DropdownMenu.SubContent>
         </DropdownMenu.Portal>
       </DropdownMenu.Sub>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, FormEvent, KeyboardEvent as ReactKeyboardEvent, MouseEvent, PointerEvent as ReactPointerEvent, ReactNode } from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import {
   AlertCircle,
   CalendarDays,
@@ -3375,6 +3376,14 @@ export function App() {
     function handleKeyDown(event: KeyboardEvent) {
       if (isTypingTarget(event.target)) return;
 
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "a") {
+        const target = event.target instanceof HTMLElement ? event.target : null;
+        if (!target?.closest(".track-list, .search-song-list, .listening-history-list")) {
+          event.preventDefault();
+        }
+        return;
+      }
+
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
         event.preventDefault();
         setSearchFocused(true);
@@ -4208,6 +4217,7 @@ export function App() {
           isFavorite={favoriteIds.songs.has(songContextMenu.song.id)}
           favoriteBusy={favoriteBusyKey === `song:${songContextMenu.song.id}`}
           onToggleFavorite={(favorite) => void toggleFavorite("song", songContextMenu.song.id, favorite)}
+          onClose={() => setSongContextMenu(null)}
         />
       ) : null}
       {libraryContextMenu ? (
@@ -4253,6 +4263,7 @@ export function App() {
             void toggleFavorite(kind, id, favorite);
             setLibraryContextMenu(null);
           }}
+          onClose={() => setLibraryContextMenu(null)}
         />
       ) : null}
       {playlistDeleteTarget ? (
@@ -8157,6 +8168,7 @@ function LibraryContextMenu({
   onEditPlaylist,
   onDeletePlaylist,
   onToggleFavorite,
+  onClose,
 }: {
   menu: Exclude<LibraryContextMenuState, null>;
   favoriteIds: FavoriteIds;
@@ -8170,20 +8182,18 @@ function LibraryContextMenu({
   onEditPlaylist: (playlist: Playlist) => void;
   onDeletePlaylist: (playlist: Playlist) => void;
   onToggleFavorite: (kind: FavoriteKind, id: string, favorite: boolean) => void;
+  onClose: () => void;
 }) {
   const title = menu.item.name;
   const menuLabel = menu.type === "album" ? "Album" : menu.type === "artist" ? "Artist" : "Playlist";
 
   return (
-    <div
-      className="song-context-menu library-context-menu"
-      style={{
-        left: Math.min(menu.x, window.innerWidth - 280),
-        top: Math.min(menu.y, window.innerHeight - 360),
-      }}
-      role="menu"
-      aria-label={`${menuLabel} actions for ${title}`}
-    >
+    <DropdownMenu.Root open onOpenChange={(open) => !open && onClose()} modal={false}>
+      <DropdownMenu.Trigger asChild>
+        <span className="context-menu-anchor" style={{ left: menu.x, top: menu.y }} />
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className="song-context-menu library-context-menu" side="right" align="start" sideOffset={4} collisionPadding={12} aria-label={`${menuLabel} actions for ${title}`}>
       <div className="song-context-heading">
         <div>
           <p className="eyebrow">{menuLabel}</p>
@@ -8262,7 +8272,9 @@ function LibraryContextMenu({
           </>
         ) : null}
       </div>
-    </div>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
   );
 }
 
@@ -8280,6 +8292,7 @@ function SongPlaylistMenu({
   isFavorite,
   favoriteBusy,
   onToggleFavorite,
+  onClose,
 }: {
   menu: Exclude<SongContextMenuState, null>;
   playlists: Playlist[];
@@ -8294,21 +8307,17 @@ function SongPlaylistMenu({
   isFavorite: boolean;
   favoriteBusy: boolean;
   onToggleFavorite: (favorite: boolean) => void;
+  onClose: () => void;
 }) {
   const sortedPlaylists = [...playlists].sort((a, b) => a.name.localeCompare(b.name));
-  const [playlistFlyoutOpen, setPlaylistFlyoutOpen] = useState(false);
-  const flyoutOpensLeft = menu.x > window.innerWidth - 560;
 
   return (
-    <div
-      className="song-context-menu"
-      style={{
-        left: Math.min(menu.x, window.innerWidth - 280),
-        top: Math.min(menu.y, window.innerHeight - 440),
-      }}
-      role="menu"
-      aria-label={`${menu.songs.length === 1 ? "Song" : `${menu.songs.length} selected songs`} actions for ${menu.song.title}`}
-    >
+    <DropdownMenu.Root open onOpenChange={(open) => !open && onClose()} modal={false}>
+      <DropdownMenu.Trigger asChild>
+        <span className="context-menu-anchor" style={{ left: menu.x, top: menu.y }} />
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className="song-context-menu" side="right" align="start" sideOffset={4} collisionPadding={12} aria-label={`${menu.songs.length === 1 ? "Song" : `${menu.songs.length} selected songs`} actions for ${menu.song.title}`}>
       <div className="song-context-heading">
         <div>
           <p className="eyebrow">{menu.songs.length === 1 ? "Song" : `${menu.songs.length} songs selected`}</p>
@@ -8344,20 +8353,14 @@ function SongPlaylistMenu({
           {isFavorite ? "Remove Favorite" : "Add Favorite"}
         </button>
       </div>
-      <div className="song-context-submenu" onMouseEnter={() => setPlaylistFlyoutOpen(true)} onMouseLeave={() => setPlaylistFlyoutOpen(false)}>
-        <button
-          className="song-context-action song-context-submenu-trigger"
-          type="button"
-          onClick={() => setPlaylistFlyoutOpen((open) => !open)}
-          aria-expanded={playlistFlyoutOpen}
-          aria-haspopup="menu"
-        >
+      <DropdownMenu.Sub>
+        <DropdownMenu.SubTrigger className="song-context-action song-context-submenu-trigger">
           <ListMusic size={15} />
           <span>Add to playlist</span>
           <ChevronRight size={15} />
-        </button>
-        {playlistFlyoutOpen ? (
-          <div className={`song-context-flyout ${flyoutOpensLeft ? "opens-left" : ""}`} role="menu" aria-label="Choose playlist">
+        </DropdownMenu.SubTrigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.SubContent className="song-context-menu song-context-flyout" sideOffset={4} collisionPadding={12} aria-label="Choose playlist">
             {sortedPlaylists.length ? (
               <div className="song-context-list">
                 {sortedPlaylists.map((playlist) => (
@@ -8379,10 +8382,12 @@ function SongPlaylistMenu({
             ) : (
               <p className="song-context-empty">Create a playlist first.</p>
             )}
-          </div>
-        ) : null}
-      </div>
-    </div>
+          </DropdownMenu.SubContent>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Sub>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
   );
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -4220,14 +4220,6 @@ button.similar-chip:hover,
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.song-context-subheading {
-  padding: 0 7px;
-  color: rgba(244, 241, 236, 0.46);
-  font-size: 10px;
-  font-weight: 500;
-  text-transform: uppercase;
-}
-
 .song-context-action,
 .song-context-list button {
   display: grid;
@@ -4240,6 +4232,39 @@ button.similar-chip:hover,
   background: transparent;
   color: rgba(244, 241, 236, 0.78);
   text-align: left;
+}
+
+.song-context-submenu {
+  position: relative;
+}
+
+.song-context-submenu-trigger {
+  width: 100%;
+  grid-template-columns: 20px minmax(0, 1fr) 16px;
+}
+
+.song-context-submenu-trigger > span {
+  min-width: 0;
+}
+
+.song-context-flyout {
+  position: absolute;
+  left: calc(100% + 6px);
+  bottom: -10px;
+  z-index: 1;
+  width: 248px;
+  max-height: min(360px, calc(100vh - 24px));
+  padding: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(17, 17, 16, 0.98);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.52);
+  overflow: hidden;
+}
+
+.song-context-flyout.opens-left {
+  right: calc(100% + 6px);
+  left: auto;
 }
 
 .song-context-action:hover:not(:disabled),

--- a/src/styles.css
+++ b/src/styles.css
@@ -17,7 +17,7 @@ body {
   min-width: 980px;
   min-height: 640px;
   margin: 0;
-  overflow: hidden;
+  overflow: visible;
 }
 
 ::-webkit-scrollbar {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1879,6 +1879,17 @@ button.similar-chip:hover,
   color: #f8df91;
 }
 
+.track-row.selected,
+.search-song-row.selected {
+  background: rgba(240, 210, 123, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(240, 210, 123, 0.48);
+}
+
+.track-row.active.selected,
+.search-song-row.active.selected {
+  background: rgba(240, 210, 123, 0.2);
+}
+
 .track-play,
 .track-queue,
 .favorite-button {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4219,6 +4219,13 @@ button.similar-chip:hover,
   overflow-y: auto;
 }
 
+.new-playlist-action {
+  width: 100%;
+  margin-top: 6px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0 0 8px 8px;
+}
+
 .song-context-section {
   display: grid;
   gap: 2px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -4173,7 +4173,6 @@ button.similar-chip:hover,
 }
 
 .song-context-menu {
-  position: fixed;
   z-index: 30;
   display: grid;
   gap: 8px;
@@ -4185,6 +4184,13 @@ button.similar-chip:hover,
   background: rgba(17, 17, 16, 0.98);
   box-shadow: 0 24px 70px rgba(0, 0, 0, 0.52);
   overflow: hidden;
+}
+
+.context-menu-anchor {
+  position: fixed;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
 }
 
 .library-context-menu {
@@ -4234,10 +4240,6 @@ button.similar-chip:hover,
   text-align: left;
 }
 
-.song-context-submenu {
-  position: relative;
-}
-
 .song-context-submenu-trigger {
   width: 100%;
   grid-template-columns: 20px minmax(0, 1fr) 16px;
@@ -4248,10 +4250,6 @@ button.similar-chip:hover,
 }
 
 .song-context-flyout {
-  position: absolute;
-  left: calc(100% + 6px);
-  bottom: -10px;
-  z-index: 1;
   width: 248px;
   max-height: min(360px, calc(100vh - 24px));
   padding: 8px;
@@ -4260,11 +4258,6 @@ button.similar-chip:hover,
   background: rgba(17, 17, 16, 0.98);
   box-shadow: 0 24px 70px rgba(0, 0, 0, 0.52);
   overflow: hidden;
-}
-
-.song-context-flyout.opens-left {
-  right: calc(100% + 6px);
-  left: auto;
 }
 
 .song-context-action:hover:not(:disabled),


### PR DESCRIPTION
## Summary

Fixes #61 by separating track selection from playback across library song lists, and adds reliable context-menu behavior for selected songs.

- A single click selects a track without interrupting playback.
- Command/Ctrl-click toggles tracks; Shift-click selects a range; Command/Ctrl+A selects the focused visible track list only (#63).
- Double-click and the explicit Play buttons still start playback.
- Add to playlist applies to the active selection through a collision-aware submenu.
- All app context menus now use Radix menu primitives for consistent keyboard, focus, hover, and viewport-collision behavior.

## Scope

This intentionally stops at selection and batch add-to-playlist. Broader library layout, drag/drop, and playlist-management work remains in #59 and #60.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Standard feature preview at `http://10.10.10.11:1420/`

## Rollback

Revert this PR's squash commit from `dev`; there are no data migrations or server-side changes.
