### PR TITLE
feat: Unify library track list layouts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6654,7 +6654,7 @@ function SearchSongList({
 
   return (
     <div className="track-list song-browser-list" ref={listRef} tabIndex={0} onKeyDown={handleKeyDown} aria-label="Songs">
-      <SongListHeader sortKey={sortKey} sortDirection={sortDirection} onSort={(key) => {
+      <SongListHeader showTrackNumber={false} sortKey={sortKey} sortDirection={sortDirection} onSort={(key) => {
         setSortDirection((direction) => key === sortKey ? (direction === "asc" ? "desc" : "asc") : "asc");
         setSortKey(key);
       }} />
@@ -6707,10 +6707,12 @@ function SearchSongList({
 }
 
 function SongListHeader({
+  showTrackNumber = true,
   sortKey,
   sortDirection,
   onSort,
 }: {
+  showTrackNumber?: boolean;
   sortKey?: SongSortKey;
   sortDirection?: SongSortDirection;
   onSort?: (key: SongSortKey) => void;
@@ -6723,7 +6725,7 @@ function SongListHeader({
   return (
     <div className="song-list-header" aria-label="Sort songs">
       <span aria-hidden="true" />
-      <span aria-hidden="true" />
+      {showTrackNumber ? <span aria-hidden="true" /> : null}
       {column("title", "Title")}
       {column("artist", "Artist")}
       {column("album", "Album")}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6683,7 +6683,7 @@ function SearchSongList({
             }}
             aria-label={`Play ${song.title}`}
           >
-            <Play size={14} fill="currentColor" />
+            <Play size={15} strokeWidth={1.6} />
           </button>
           <button className="track-name" type="button" aria-label={`Select ${song.title}`}>{song.title}</button>
           <span className="track-artist">{song.artist || "Unknown artist"}</span>
@@ -6807,7 +6807,7 @@ function ListeningHistoryView({
               }}
               aria-label={`Play ${entry.song.title}`}
             >
-              <Play size={14} fill="currentColor" />
+              <Play size={15} strokeWidth={1.6} />
             </button>
             <button className="track-name history-track-name" type="button" aria-label={`Select ${entry.song.title}`}>
               <strong>{entry.song.title}</strong>
@@ -7091,7 +7091,7 @@ function AlbumList({
                 </span>
               </button>
               <button className="track-play" type="button" onClick={() => onPlayAlbum(album)} aria-label={`Play ${album.name}`}>
-                <Play size={14} fill="currentColor" />
+                <Play size={15} strokeWidth={1.6} />
               </button>
               <FavoriteButton
                 active={favoriteIds.albums.has(album.id)}
@@ -7127,7 +7127,7 @@ function AlbumList({
                       </span>
                     </button>
                     <button className="track-play" type="button" onClick={() => onPlayAlbum(album)} aria-label={`Play ${album.name}`}>
-                      <Play size={14} fill="currentColor" />
+                      <Play size={15} strokeWidth={1.6} />
                     </button>
                     <FavoriteButton
                       active={favoriteIds.albums.has(album.id)}
@@ -7348,7 +7348,7 @@ function ArtistList({
               <small>{artist.albumCount ?? 0} albums</small>
             </button>
             <button className="track-play" type="button" onClick={() => onPlayArtist(artist)} aria-label={`Play ${artist.name}`}>
-              <Play size={14} fill="currentColor" />
+              <Play size={15} strokeWidth={1.6} />
             </button>
             <FavoriteButton
               active={favoriteIds.artists.has(artist.id)}
@@ -7379,7 +7379,7 @@ function ArtistList({
                     <small>{artist.albumCount ?? 0} albums</small>
                   </button>
                   <button className="track-play" type="button" onClick={() => onPlayArtist(artist)} aria-label={`Play ${artist.name}`}>
-                    <Play size={14} fill="currentColor" />
+                    <Play size={15} strokeWidth={1.6} />
                   </button>
                   <FavoriteButton
                     active={favoriteIds.artists.has(artist.id)}
@@ -7515,7 +7515,7 @@ function PlaylistBrowser({
             </span>
           </button>
           <button className="track-play" type="button" onClick={() => onPlayPlaylist(playlist)} aria-label={`Play ${playlist.name}`}>
-            <Play size={14} fill="currentColor" />
+            <Play size={15} strokeWidth={1.6} />
           </button>
         </div>
       ))}
@@ -8141,7 +8141,7 @@ function TrackList({
                   }}
                   onDoubleClick={(event) => event.stopPropagation()}
                 >
-                  <Play size={14} fill="currentColor" />
+                  <Play size={15} strokeWidth={1.6} />
                 </button>
               </span>
               <button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6707,11 +6707,15 @@ function SearchSongList({
 }
 
 function SongListHeader({
+  showAlbum = true,
+  showPlayColumn = true,
   showTrackNumber = true,
   sortKey,
   sortDirection,
   onSort,
 }: {
+  showAlbum?: boolean;
+  showPlayColumn?: boolean;
   showTrackNumber?: boolean;
   sortKey?: SongSortKey;
   sortDirection?: SongSortDirection;
@@ -6724,12 +6728,12 @@ function SongListHeader({
 
   return (
     <div className="song-list-header" aria-label="Sort songs">
-      <span aria-hidden="true" />
+      {showPlayColumn ? <span aria-hidden="true" /> : null}
       {showTrackNumber ? <span aria-hidden="true" /> : null}
       {column("title", "Title")}
       {column("artist", "Artist")}
-      {column("album", "Album")}
-      {column("duration", "Length")}
+      {showAlbum ? column("album", "Album") : null}
+      <span aria-hidden="true" />
       <span aria-hidden="true" />
       <span aria-hidden="true" />
     </div>
@@ -8094,8 +8098,8 @@ function TrackList({
   const showDiscHeaders = discGroups.length > 1;
 
   return (
-    <div className="track-list" ref={listRef} tabIndex={0} onKeyDown={handleKeyDown} aria-label="Album tracks">
-      <SongListHeader sortKey={sortKey} sortDirection={sortDirection} onSort={(key) => {
+    <div className="track-list album-track-list" ref={listRef} tabIndex={0} onKeyDown={handleKeyDown} aria-label="Album tracks">
+      <SongListHeader showAlbum={false} showPlayColumn={false} sortKey={sortKey} sortDirection={sortDirection} onSort={(key) => {
         setSortDirection((direction) => key === sortKey ? (direction === "asc" ? "desc" : "asc") : "asc");
         setSortKey(key);
       }} />
@@ -8112,25 +8116,27 @@ function TrackList({
 
             return (
             <div
-              className={`track-row ${currentTrack?.id === song.id ? "active" : ""} ${isSelected(songIndex) ? "selected" : ""}`}
+              className={`track-row album-track-row ${currentTrack?.id === song.id ? "active" : ""} ${isSelected(songIndex) ? "selected" : ""}`}
               key={song.id}
               onContextMenu={(event) => onSongContextMenu(event, song, selectedSongs)}
               onClick={(event) => selectTrack(event, songIndex)}
               onDoubleClick={() => onPlaySong(song)}
             >
-              <button
-                className="track-play"
-                type="button"
-                aria-label={`Play ${song.title}`}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onPlaySong(song);
-                }}
-                onDoubleClick={(event) => event.stopPropagation()}
-              >
-                <Play size={14} fill="currentColor" />
-              </button>
-              <span className="track-number">{song.track ?? index + 1}</span>
+              <span className="track-index">
+                <span className="track-number">{song.track ?? index + 1}</span>
+                <button
+                  className="track-play"
+                  type="button"
+                  aria-label={`Play ${song.title}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onPlaySong(song);
+                  }}
+                  onDoubleClick={(event) => event.stopPropagation()}
+                >
+                  <Play size={14} fill="currentColor" />
+                </button>
+              </span>
               <button
                 className="track-name"
                 type="button"
@@ -8139,7 +8145,6 @@ function TrackList({
                 {song.title}
               </button>
               <span className="track-artist">{song.artist || "Unknown artist"}</span>
-              <span className="track-album">{song.album || "Unknown album"}</span>
               <span className="track-duration">{formatDuration(song.duration)}</span>
               <FavoriteButton
                 active={favoriteIds.songs.has(song.id)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,8 @@ type ArtistViewMode = "art" | "list";
 type RepeatMode = "off" | "all" | "one";
 type RightPanelTab = "queue" | "nowPlaying" | "lyrics";
 type LyricsStatus = "idle" | "loading" | "ready" | "empty" | "error";
+type SongSortKey = "title" | "artist" | "album" | "duration";
+type SongSortDirection = "asc" | "desc";
 
 function ViewportModal({ children, className = "" }: { children: ReactNode; className?: string }) {
   return createPortal(<div className={`modal-backdrop ${className}`.trim()}>{children}</div>, document.body);
@@ -1607,6 +1609,16 @@ function formatDuration(seconds?: number) {
   const minutes = Math.floor(wholeSeconds / 60);
   const remainingSeconds = wholeSeconds % 60;
   return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
+}
+
+function sortSongs(songs: Song[], key: SongSortKey, direction: SongSortDirection) {
+  const factor = direction === "asc" ? 1 : -1;
+  return [...songs].sort((left, right) => {
+    if (key === "duration") return ((left.duration ?? 0) - (right.duration ?? 0)) * factor;
+    const leftValue = key === "title" ? left.title : left[key] ?? "";
+    const rightValue = key === "title" ? right.title : right[key] ?? "";
+    return leftValue.localeCompare(rightValue, undefined, { sensitivity: "base" }) * factor;
+  });
 }
 
 function getSongDisc(song: Song) {
@@ -6636,12 +6648,21 @@ function SearchSongList({
   onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
   const { isSelected, selectTrack, selectedSongs, handleKeyDown, listRef } = useTrackSelection(songs);
+  const [sortKey, setSortKey] = useState<SongSortKey>("title");
+  const [sortDirection, setSortDirection] = useState<SongSortDirection>("asc");
+  const sortedSongs = useMemo(() => sortSongs(songs, sortKey, sortDirection), [songs, sortKey, sortDirection]);
 
   return (
-    <div className="search-song-list" ref={listRef} tabIndex={0} onKeyDown={handleKeyDown} aria-label="Songs">
-      {songs.map((song, index) => (
+    <div className="track-list song-browser-list" ref={listRef} tabIndex={0} onKeyDown={handleKeyDown} aria-label="Songs">
+      <SongListHeader sortKey={sortKey} sortDirection={sortDirection} onSort={(key) => {
+        setSortDirection((direction) => key === sortKey ? (direction === "asc" ? "desc" : "asc") : "asc");
+        setSortKey(key);
+      }} />
+      {sortedSongs.map((song) => {
+        const index = songs.findIndex((listSong) => listSong.id === song.id);
+        return (
         <div
-          className={`search-song-row ${currentTrack?.id === song.id ? "active" : ""} ${isSelected(index) ? "selected" : ""}`}
+          className={`track-row song-browser-row ${currentTrack?.id === song.id ? "active" : ""} ${isSelected(index) ? "selected" : ""}`}
           key={song.id}
           onContextMenu={(event) => onSongContextMenu(event, song, selectedSongs)}
           onClick={(event) => selectTrack(event, index)}
@@ -6657,11 +6678,10 @@ function SearchSongList({
           >
             <Play size={14} fill="currentColor" />
           </button>
-          <button className="search-song-main" type="button" aria-label={`Select ${song.title}`}>
-            <strong>{song.title}</strong>
-            <small>{[song.artist, song.album].filter(Boolean).join(" - ") || "Song"}</small>
-          </button>
-          <small>{formatDuration(song.duration)}</small>
+          <button className="track-name" type="button" aria-label={`Select ${song.title}`}>{song.title}</button>
+          <span className="track-artist">{song.artist || "Unknown artist"}</span>
+          <span className="track-album">{song.album || "Unknown album"}</span>
+          <span className="track-duration">{formatDuration(song.duration)}</span>
           <FavoriteButton
             active={favoriteIds.songs.has(song.id)}
             busy={favoriteBusyKey === `song:${song.id}`}
@@ -6680,7 +6700,36 @@ function SearchSongList({
             <Plus size={14} />
           </button>
         </div>
-      ))}
+        );
+      })}
+    </div>
+  );
+}
+
+function SongListHeader({
+  sortKey,
+  sortDirection,
+  onSort,
+}: {
+  sortKey?: SongSortKey;
+  sortDirection?: SongSortDirection;
+  onSort?: (key: SongSortKey) => void;
+}) {
+  const label = (key: SongSortKey, text: string) => `${text}${sortKey === key ? `, sorted ${sortDirection === "asc" ? "ascending" : "descending"}` : ""}`;
+  const column = (key: SongSortKey, text: string) => onSort ? (
+    <button type="button" onClick={() => onSort(key)} aria-label={label(key, `Sort by ${text.toLocaleLowerCase()}`)}>{text}</button>
+  ) : <span>{text}</span>;
+
+  return (
+    <div className="song-list-header" aria-label="Sort songs">
+      <span aria-hidden="true" />
+      <span aria-hidden="true" />
+      {column("title", "Title")}
+      {column("artist", "Artist")}
+      {column("album", "Album")}
+      {column("duration", "Length")}
+      <span aria-hidden="true" />
+      <span aria-hidden="true" />
     </div>
   );
 }
@@ -7017,7 +7066,7 @@ function AlbumList({
       <div className="album-list">
         {albums.map((album) => {
           const coverUrl = config ? buildCoverArtUrl(config, album.coverArt, "160") : null;
-          const detailParts = [album.year, album.songCount ? `${album.songCount} tracks` : null].filter(Boolean);
+          const detailParts = [album.artist, album.year, album.songCount ? `${album.songCount} tracks` : null].filter(Boolean);
 
           return (
             <div className="album-list-row" key={album.id} data-context-kind="album" data-context-id={album.id}>
@@ -8031,16 +8080,23 @@ function TrackList({
   onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
   const { isSelected, selectTrack, selectedSongs, handleKeyDown, listRef } = useTrackSelection(songs);
+  const [sortKey, setSortKey] = useState<SongSortKey>("title");
+  const [sortDirection, setSortDirection] = useState<SongSortDirection>("asc");
 
   if (!songs.length) {
     return <EmptyPanel icon={<Music2 size={20} />} text={emptyText} />;
   }
 
-  const discGroups = groupSongsByDisc(songs);
+  const sortedSongs = sortSongs(songs, sortKey, sortDirection);
+  const discGroups = groupSongsByDisc(sortedSongs);
   const showDiscHeaders = discGroups.length > 1;
 
   return (
     <div className="track-list" ref={listRef} tabIndex={0} onKeyDown={handleKeyDown} aria-label="Album tracks">
+      <SongListHeader sortKey={sortKey} sortDirection={sortDirection} onSort={(key) => {
+        setSortDirection((direction) => key === sortKey ? (direction === "asc" ? "desc" : "asc") : "asc");
+        setSortKey(key);
+      }} />
       {discGroups.map((group) => (
         <div className="disc-group" key={group.discNumber ?? "unknown-disc"}>
           {showDiscHeaders ? (
@@ -8080,6 +8136,8 @@ function TrackList({
               >
                 {song.title}
               </button>
+              <span className="track-artist">{song.artist || "Unknown artist"}</span>
+              <span className="track-album">{song.album || "Unknown album"}</span>
               <span className="track-duration">{formatDuration(song.duration)}</span>
               <FavoriteButton
                 active={favoriteIds.songs.has(song.id)}
@@ -8167,6 +8225,7 @@ function EditablePlaylistTrackList({
         {message ? <span className={busy ? "" : "bad"}>{message}</span> : null}
       </div>
       <div className="track-list" ref={listRef} tabIndex={0} onKeyDown={handleKeyDown} aria-label="Playlist tracks">
+        <SongListHeader />
         {displayedSongs.map(({ song, index }, displayIndex) => (
           <div
             className={`track-row playlist-track-row ${currentTrack?.id === song.id ? "active" : ""} ${isSelected(index) ? "selected" : ""} ${index === draggedIndex ? "dragging" : ""}`}
@@ -8208,6 +8267,8 @@ function EditablePlaylistTrackList({
             >
               {song.title}
             </button>
+            <span className="track-artist">{song.artist || "Unknown artist"}</span>
+            <span className="track-album">{song.album || "Unknown album"}</span>
             <span className="track-duration">{formatDuration(song.duration)}</span>
             <FavoriteButton
               active={favoriteIds.songs.has(song.id)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6717,6 +6717,7 @@ function SongListHeader({
   showAlbum = true,
   showPlayColumn = true,
   showTrackNumber = true,
+  showQueueColumn = true,
   sortKey,
   sortDirection,
   onSort,
@@ -6724,6 +6725,7 @@ function SongListHeader({
   showAlbum?: boolean;
   showPlayColumn?: boolean;
   showTrackNumber?: boolean;
+  showQueueColumn?: boolean;
   sortKey?: SongSortKey;
   sortDirection?: SongSortDirection;
   onSort?: (key: SongSortKey) => void;
@@ -6740,9 +6742,9 @@ function SongListHeader({
       {column("title", "Title")}
       {column("artist", "Artist")}
       {showAlbum ? column("album", "Album") : null}
+      {column("duration", "Length")}
       <span aria-hidden="true" />
-      <span aria-hidden="true" />
-      <span aria-hidden="true" />
+      {showQueueColumn ? <span aria-hidden="true" /> : null}
     </div>
   );
 }
@@ -8064,7 +8066,6 @@ function DetailPanel({
         favoriteBusyKey={favoriteBusyKey}
         onToggleFavorite={onToggleFavorite}
         onPlaySong={(song) => onReplaceQueue(songs, Math.max(0, songs.findIndex((albumSong) => albumSong.id === song.id)))}
-        onQueueSong={onQueueSong}
         onSongContextMenu={onSongContextMenu}
       />
     </section>
@@ -8079,7 +8080,6 @@ function TrackList({
   onToggleFavorite,
   emptyText = "No tracks available for this album.",
   onPlaySong,
-  onQueueSong,
   onSongContextMenu,
 }: {
   songs: Song[];
@@ -8089,7 +8089,6 @@ function TrackList({
   onToggleFavorite: (kind: FavoriteKind, id: string, favorite: boolean) => void;
   emptyText?: string;
   onPlaySong: (song: Song) => void;
-  onQueueSong: (song: Song) => void;
   onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
   const { isSelected, selectTrack, selectedSongs, handleKeyDown, listRef } = useTrackSelection(songs);
@@ -8106,7 +8105,7 @@ function TrackList({
 
   return (
     <div className="track-list album-track-list" ref={listRef} tabIndex={0} onKeyDown={handleKeyDown} aria-label="Album tracks">
-      <SongListHeader showAlbum={false} showPlayColumn={false} sortKey={sortKey} sortDirection={sortDirection} onSort={(key) => {
+      <SongListHeader showAlbum={false} showPlayColumn={false} showQueueColumn={false} sortKey={sortKey} sortDirection={sortDirection} onSort={(key) => {
         setSortDirection((direction) => key === sortKey ? (direction === "asc" ? "desc" : "asc") : "asc");
         setSortKey(key);
       }} />
@@ -8160,18 +8159,6 @@ function TrackList({
                 onToggle={(favorite) => onToggleFavorite("song", song.id, favorite)}
                 onDoubleClick={(event) => event.stopPropagation()}
               />
-              <button
-                className="track-queue"
-                type="button"
-                aria-label={`Queue ${song.title}`}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onQueueSong(song);
-                }}
-                onDoubleClick={(event) => event.stopPropagation()}
-              >
-                <Plus size={14} />
-              </button>
             </div>
             );
           })}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,7 @@ type ArtistViewMode = "art" | "list";
 type RepeatMode = "off" | "all" | "one";
 type RightPanelTab = "queue" | "nowPlaying" | "lyrics";
 type LyricsStatus = "idle" | "loading" | "ready" | "empty" | "error";
-type SongSortKey = "title" | "artist" | "album" | "duration";
+type SongSortKey = "title" | "artist" | "album" | "duration" | "track";
 type SongSortDirection = "asc" | "desc";
 
 function ViewportModal({ children, className = "" }: { children: ReactNode; className?: string }) {
@@ -1615,6 +1615,13 @@ function sortSongs(songs: Song[], key: SongSortKey, direction: SongSortDirection
   const factor = direction === "asc" ? 1 : -1;
   return [...songs].sort((left, right) => {
     if (key === "duration") return ((left.duration ?? 0) - (right.duration ?? 0)) * factor;
+    if (key === "track") {
+      return (
+        getSongDisc(left) - getSongDisc(right)
+        || getSongTrack(left) - getSongTrack(right)
+        || left.title.localeCompare(right.title)
+      ) * factor;
+    }
     const leftValue = key === "title" ? left.title : left[key] ?? "";
     const rightValue = key === "title" ? right.title : right[key] ?? "";
     return leftValue.localeCompare(rightValue, undefined, { sensitivity: "base" }) * factor;
@@ -8086,7 +8093,7 @@ function TrackList({
   onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
   const { isSelected, selectTrack, selectedSongs, handleKeyDown, listRef } = useTrackSelection(songs);
-  const [sortKey, setSortKey] = useState<SongSortKey>("title");
+  const [sortKey, setSortKey] = useState<SongSortKey>("track");
   const [sortDirection, setSortDirection] = useState<SongSortDirection>("asc");
 
   if (!songs.length) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1846,7 +1846,7 @@ button.similar-chip:hover,
 }
 
 .album-track-row {
-  grid-template-columns: 26px minmax(200px, 2fr) minmax(140px, 1fr) 42px 28px 28px;
+  grid-template-columns: 26px minmax(200px, 2fr) minmax(140px, 1fr) 42px 28px;
 }
 
 .song-list-header {
@@ -1863,7 +1863,7 @@ button.similar-chip:hover,
 }
 
 .album-track-list > .song-list-header {
-  grid-template-columns: 26px minmax(200px, 2fr) minmax(140px, 1fr) 42px 28px 28px;
+  grid-template-columns: 26px minmax(200px, 2fr) minmax(140px, 1fr) 42px 28px;
 }
 
 .song-list-header button,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1820,13 +1820,51 @@ button.similar-chip:hover,
 
 .track-row {
   display: grid;
-  grid-template-columns: 28px 26px minmax(0, 1fr) 38px 28px 28px;
+  grid-template-columns: 28px 26px minmax(140px, 1.5fr) minmax(112px, 1fr) minmax(112px, 1fr) 42px 28px 28px;
   align-items: center;
   gap: 6px;
   min-height: 34px;
   padding: 0 6px;
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.05);
+}
+
+.song-list-header {
+  display: grid;
+  grid-template-columns: 28px 26px minmax(140px, 1.5fr) minmax(112px, 1fr) minmax(112px, 1fr) 42px 28px 28px;
+  align-items: center;
+  gap: 6px;
+  min-height: 28px;
+  padding: 0 6px;
+}
+
+.song-list-header button,
+.song-list-header > span {
+  overflow: hidden;
+  padding: 0;
+  background: transparent;
+  color: rgba(244, 241, 236, 0.46);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-align: left;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.song-list-header button:hover,
+.song-list-header button:focus-visible {
+  color: #f2d985;
+}
+
+.track-artist,
+.track-album {
+  overflow: hidden;
+  color: rgba(244, 241, 236, 0.58);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .playlist-track-editor {
@@ -1853,7 +1891,7 @@ button.similar-chip:hover,
 }
 
 .track-row.playlist-track-row {
-  grid-template-columns: 28px 26px minmax(0, 1fr) 38px 28px 28px 28px;
+  grid-template-columns: 28px 26px minmax(140px, 1.5fr) minmax(112px, 1fr) minmax(112px, 1fr) 42px 28px 28px 28px;
 }
 
 .track-row.playlist-track-row.dragging {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1839,6 +1839,10 @@ button.similar-chip:hover,
   grid-template-columns: 28px minmax(200px, 2fr) minmax(130px, 1fr) minmax(150px, 1.15fr) 42px 28px 28px;
 }
 
+.album-track-row {
+  grid-template-columns: 26px minmax(200px, 2fr) minmax(140px, 1fr) 42px 28px 28px;
+}
+
 .song-list-header {
   display: grid;
   grid-template-columns: 28px 26px minmax(140px, 1.5fr) minmax(112px, 1fr) minmax(112px, 1fr) 42px 28px 28px;
@@ -1850,6 +1854,10 @@ button.similar-chip:hover,
 
 .song-browser-list > .song-list-header {
   grid-template-columns: 28px minmax(200px, 2fr) minmax(130px, 1fr) minmax(150px, 1.15fr) 42px 28px 28px;
+}
+
+.album-track-list > .song-list-header {
+  grid-template-columns: 26px minmax(200px, 2fr) minmax(140px, 1fr) 42px 28px 28px;
 }
 
 .song-list-header button,
@@ -1951,6 +1959,29 @@ button.similar-chip:hover,
   height: 24px;
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.08);
+}
+
+.track-row .track-play {
+  opacity: 0;
+}
+
+.track-row:hover .track-play,
+.track-row:focus-within .track-play {
+  opacity: 1;
+}
+
+.track-index {
+  display: grid;
+  place-items: center;
+}
+
+.track-index > * {
+  grid-area: 1 / 1;
+}
+
+.album-track-row:hover .track-number,
+.album-track-row:focus-within .track-number {
+  opacity: 0;
 }
 
 .favorite-button {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1846,7 +1846,7 @@ button.similar-chip:hover,
 }
 
 .album-track-row {
-  grid-template-columns: 26px minmax(200px, 2fr) minmax(140px, 1fr) 42px 28px;
+  grid-template-columns: 26px minmax(200px, 2fr) minmax(140px, 1fr) 52px 28px;
 }
 
 .song-list-header {
@@ -1863,7 +1863,7 @@ button.similar-chip:hover,
 }
 
 .album-track-list > .song-list-header {
-  grid-template-columns: 26px minmax(200px, 2fr) minmax(140px, 1fr) 42px 28px;
+  grid-template-columns: 26px minmax(200px, 2fr) minmax(140px, 1fr) 52px 28px;
 }
 
 .song-list-header button,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1748,12 +1748,12 @@ button.similar-chip:hover,
 .album-stack,
 .track-list {
   display: grid;
-  gap: 6px;
+  gap: 0;
 }
 
 .disc-group {
   display: grid;
-  gap: 6px;
+  gap: 0;
 }
 
 .disc-heading {
@@ -1825,8 +1825,18 @@ button.similar-chip:hover,
   gap: 6px;
   min-height: 34px;
   padding: 0 6px;
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.05);
+  border-radius: 0;
+  background: transparent;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+}
+
+.track-list > .track-row:nth-child(even),
+.disc-group > .track-row:nth-child(even) {
+  background: rgba(255, 255, 255, 0.032);
+}
+
+.song-browser-row {
+  grid-template-columns: 28px minmax(200px, 2fr) minmax(130px, 1fr) minmax(150px, 1.15fr) 42px 28px 28px;
 }
 
 .song-list-header {
@@ -1836,6 +1846,10 @@ button.similar-chip:hover,
   gap: 6px;
   min-height: 28px;
   padding: 0 6px;
+}
+
+.song-browser-list > .song-list-header {
+  grid-template-columns: 28px minmax(200px, 2fr) minmax(130px, 1fr) minmax(150px, 1.15fr) 42px 28px 28px;
 }
 
 .song-list-header button,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1835,6 +1835,12 @@ button.similar-chip:hover,
   background: rgba(255, 255, 255, 0.032);
 }
 
+/* Keep the hover surface consistent over both alternating row colors. */
+.track-list > .track-row:hover,
+.disc-group > .track-row:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
 .song-browser-row {
   grid-template-columns: 28px minmax(200px, 2fr) minmax(130px, 1fr) minmax(150px, 1.15fr) 42px 28px 28px;
 }


### PR DESCRIPTION
## Summary

Establishes the first shared library-list system so track browsing reads consistently across Prism.

## Changes

- Standardize Songs, search results, album tracks, and playlist tracks into Title, Artist, Album, and Length columns.
- Add sortable headers to Songs, search results, and album tracks.
- Preserve playlist ordering while giving playlist tracks the same column rhythm.
- Display releasing artist metadata in Recently Added album rows.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Preview served at `http://10.10.10.11:1420/`

## Follow-up

This is the first visual-system pass. Album and Artist browse cards remain intentionally distinct, with their existing Art/List modes, for refinement from preview feedback.

## Rollback

Revert this PR's squash commit to restore the previous list layouts.
