### PR TITLE
feat: Add a sidebar playlist flyout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import {
   AlertCircle,
   CalendarDays,
   Code2,
-  ChevronDown,
   ChevronLeft,
   ChevronRight,
   CheckCircle2,
@@ -105,8 +104,6 @@ type AppSettings = {
   lastVolume: number;
   defaultAlbumView: AlbumViewMode;
   defaultArtistView: ArtistViewMode;
-  showSidebarPlaylists: boolean;
-  sidebarPlaylistLimit: number;
   analyticsEnabled: boolean;
   analyticsPromptDismissed: boolean;
   updateDismissedVersion: string;
@@ -420,8 +417,6 @@ const defaultSettings: AppSettings = {
   lastVolume: 0.82,
   defaultAlbumView: "art",
   defaultArtistView: "list",
-  showSidebarPlaylists: true,
-  sidebarPlaylistLimit: 8,
   analyticsEnabled: false,
   analyticsPromptDismissed: false,
   updateDismissedVersion: "",
@@ -568,8 +563,6 @@ function loadStoredSettings(): AppSettings {
       lastVolume: clampNumber(Number(parsed.lastVolume ?? parsed.defaultVolume ?? defaultSettings.lastVolume), 0, 1),
       defaultAlbumView: parsed.defaultAlbumView === "list" ? "list" : "art",
       defaultArtistView: parsed.defaultArtistView === "art" ? "art" : "list",
-      showSidebarPlaylists: parsed.showSidebarPlaylists ?? defaultSettings.showSidebarPlaylists,
-      sidebarPlaylistLimit: clampNumber(Number(parsed.sidebarPlaylistLimit ?? defaultSettings.sidebarPlaylistLimit), 3, 20),
       analyticsEnabled: Boolean(parsed.analyticsEnabled),
       analyticsPromptDismissed: Boolean(parsed.analyticsPromptDismissed),
       updateDismissedVersion: typeof parsed.updateDismissedVersion === "string" ? parsed.updateDismissedVersion : "",
@@ -1697,7 +1690,6 @@ export function App() {
   const [searchStatus, setSearchStatus] = useState<"idle" | "searching" | "error">("idle");
   const [searchFocused, setSearchFocused] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => loadStoredBoolean(SIDEBAR_COLLAPSED_KEY, false));
-  const [sidebarPlaylistsOpen, setSidebarPlaylistsOpen] = useState(true);
   const [albumViewMode, setAlbumViewMode] = useState<AlbumViewMode>(() => loadStoredSettings().defaultAlbumView);
   const [artistViewMode, setArtistViewMode] = useState<ArtistViewMode>(() => loadStoredSettings().defaultArtistView);
   const [settingsTab, setSettingsTab] = useState<SettingsTab>("connection");
@@ -1914,7 +1906,6 @@ export function App() {
     return {
       ...nextSettings,
       lastVolume: clampNumber(nextSettings.lastVolume, 0, 1),
-      sidebarPlaylistLimit: Math.round(clampNumber(nextSettings.sidebarPlaylistLimit, 3, 20)),
       radioStationUrl: activeStation,
       radioStationUrls: radioStationUrls.includes(activeStation) ? radioStationUrls : normalizeRadioStationList([activeStation, ...radioStationUrls]),
     };
@@ -3725,43 +3716,60 @@ export function App() {
             <Music2 size={18} />
             Songs
           </button>
-          <div className="nav-parent-row">
-            <button
-              className={`nav-item nav-child nav-parent ${activeView === "playlists" ? "active" : ""}`}
-              type="button"
-              onClick={() => selectView("playlists")}
-            >
-              <ListMusic size={18} />
-              <span>Playlists</span>
-            </button>
-            <button
-              className={`nav-toggle ${sidebarPlaylistsOpen ? "open" : ""}`}
-              type="button"
-              onClick={() => setSidebarPlaylistsOpen((value) => !value)}
-              aria-label={`${sidebarPlaylistsOpen ? "Collapse" : "Expand"} playlists`}
-              aria-expanded={sidebarPlaylistsOpen}
-            >
-              {sidebarPlaylistsOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-            </button>
-          </div>
-          {appSettings.showSidebarPlaylists && sidebarPlaylistsOpen && libraryData.playlists.length ? (
-            <div className="nav-playlist-list" aria-label="Playlist shortcuts">
-              {libraryData.playlists.slice(0, appSettings.sidebarPlaylistLimit).map((playlist) => (
-                <button
-                  className={`nav-item nav-child nav-playlist ${
-                    detailSelection?.type === "playlist" && detailSelection.data.id === playlist.id ? "active" : ""
-                  }`}
-                  type="button"
-                  key={playlist.id}
-                  data-context-kind="playlist"
-                  data-context-id={playlist.id}
-                  onClick={() => void openPlaylist(playlist)}
-                >
-                  <span>{playlist.name}</span>
-                </button>
-              ))}
-            </div>
-          ) : null}
+          <DropdownMenu.Root modal={false}>
+            <DropdownMenu.Trigger asChild>
+              <button
+                className={`nav-item nav-child nav-parent nav-playlist-trigger ${activeView === "playlists" ? "active" : ""}`}
+                type="button"
+                aria-label="Open playlists"
+              >
+                <ListMusic size={18} />
+                <span>Playlists</span>
+                <ChevronRight size={16} aria-hidden="true" />
+              </button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content
+                className="sidebar-playlist-menu"
+                side="right"
+                align="start"
+                sideOffset={10}
+                collisionPadding={12}
+                aria-label="Playlists"
+              >
+                <DropdownMenu.Item asChild>
+                  <button className="sidebar-playlist-menu-all" type="button" onClick={() => selectView("playlists")}>
+                    <ListMusic size={15} />
+                    <span>All playlists</span>
+                  </button>
+                </DropdownMenu.Item>
+                {libraryData.playlists.length ? (
+                  <div className="sidebar-playlist-menu-list">
+                    {libraryData.playlists
+                      .slice()
+                      .sort((a, b) => a.name.localeCompare(b.name))
+                      .map((playlist) => (
+                        <DropdownMenu.Item asChild key={playlist.id}>
+                          <button
+                            className={detailSelection?.type === "playlist" && detailSelection.data.id === playlist.id ? "active" : ""}
+                            type="button"
+                            data-context-kind="playlist"
+                            data-context-id={playlist.id}
+                            onClick={() => void openPlaylist(playlist)}
+                          >
+                            <ListMusic size={15} />
+                            <span>{playlist.name}</span>
+                            <small>{getPlaylistMeta(playlist)}</small>
+                          </button>
+                        </DropdownMenu.Item>
+                      ))}
+                  </div>
+                ) : (
+                  <p className="sidebar-playlist-menu-empty">No playlists yet.</p>
+                )}
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Root>
           <button
             className={`nav-item nav-child ${activeView === "recentlyAdded" ? "active" : ""}`}
             type="button"
@@ -5280,35 +5288,6 @@ function SettingsView({
             <option value="list">List</option>
             <option value="art">Art</option>
           </select>
-        </label>
-      </section> : null}
-
-      {activeTab === "library" ? <section className="settings-panel">
-        <div className="panel-heading">
-          <div>
-            <p className="eyebrow">Sidebar</p>
-            <h3>Playlist shortcuts</h3>
-          </div>
-          <ListMusic size={18} />
-        </div>
-        <label className="settings-checkbox">
-          <input
-            type="checkbox"
-            checked={appSettings.showSidebarPlaylists}
-            onChange={(event) => updateAppSettings({ ...appSettings, showSidebarPlaylists: event.target.checked })}
-          />
-          <span>Show playlists</span>
-        </label>
-        <label>
-          Playlist count
-          <input
-            type="number"
-            min="3"
-            max="20"
-            value={appSettings.sidebarPlaylistLimit}
-            disabled={!appSettings.showSidebarPlaylists}
-            onChange={(event) => updateAppSettings({ ...appSettings, sidebarPlaylistLimit: Number(event.target.value) })}
-          />
         </label>
       </section> : null}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3771,8 +3771,10 @@ export function App() {
                             onClick={() => void openPlaylist(playlist)}
                           >
                             <ListMusic size={15} />
-                            <span>{playlist.name}</span>
-                            <small>{getPlaylistMeta(playlist)}</small>
+                            <span className="sidebar-playlist-menu-copy">
+                              <strong>{playlist.name}</strong>
+                              <small>{getSidebarPlaylistMeta(playlist)}</small>
+                            </span>
                           </button>
                         </DropdownMenu.Item>
                       ))}
@@ -3788,8 +3790,10 @@ export function App() {
                             onClick={() => void openPlaylist(playlist)}
                           >
                             <ListMusic size={15} />
-                            <span>{playlist.name}</span>
-                            <small>{getPlaylistMeta(playlist)}</small>
+                            <span className="sidebar-playlist-menu-copy">
+                              <strong>{playlist.name}</strong>
+                              <small>{getSidebarPlaylistMeta(playlist, true)}</small>
+                            </span>
                           </button>
                         </DropdownMenu.Item>
                       ))}
@@ -3798,6 +3802,12 @@ export function App() {
                 ) : (
                   <p className="sidebar-playlist-menu-empty">No playlists yet.</p>
                 )}
+                <DropdownMenu.Item asChild>
+                  <button className="sidebar-playlist-menu-create" type="button" onClick={() => setPlaylistCreatorOpen(true)}>
+                    <Plus size={15} />
+                    New playlist
+                  </button>
+                </DropdownMenu.Item>
               </DropdownMenu.Content>
             </DropdownMenu.Portal>
           </DropdownMenu.Root>
@@ -7487,6 +7497,26 @@ function getPlaylistMeta(playlist: Playlist) {
   ].filter(Boolean);
 
   return parts.join(" - ") || "Playlist";
+}
+
+function formatPlaylistDuration(seconds?: number) {
+  if (!seconds || !Number.isFinite(seconds)) return null;
+  const totalMinutes = Math.floor(Math.max(0, seconds) / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours) return `${hours}h${minutes ? ` ${minutes}m` : ""}`;
+  return `${Math.max(1, totalMinutes)}m`;
+}
+
+function getSidebarPlaylistMeta(playlist: Playlist, includeOwner = false) {
+  const parts = [
+    includeOwner && playlist.owner ? `by ${playlist.owner}` : null,
+    playlist.songCount != null ? `${playlist.songCount} songs` : null,
+    formatPlaylistDuration(playlist.duration),
+  ].filter(Boolean);
+
+  return parts.join(" · ") || "Playlist";
 }
 
 function PlaylistDetailPanel({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,6 +109,7 @@ type AppSettings = {
   updateDismissedVersion: string;
   coverWashEnabled: boolean;
   lowPerformanceMode: boolean;
+  showSharedPlaylists: boolean;
   radioStationUrl: string;
   radioStationUrls: string[];
 };
@@ -422,6 +423,7 @@ const defaultSettings: AppSettings = {
   updateDismissedVersion: "",
   coverWashEnabled: true,
   lowPerformanceMode: false,
+  showSharedPlaylists: true,
   radioStationUrl: "",
   radioStationUrls: [],
 };
@@ -568,6 +570,7 @@ function loadStoredSettings(): AppSettings {
       updateDismissedVersion: typeof parsed.updateDismissedVersion === "string" ? parsed.updateDismissedVersion : "",
       coverWashEnabled: parsed.coverWashEnabled ?? defaultSettings.coverWashEnabled,
       lowPerformanceMode: Boolean(parsed.lowPerformanceMode),
+      showSharedPlaylists: parsed.showSharedPlaylists ?? defaultSettings.showSharedPlaylists,
       radioStationUrl: activeStation || radioStationUrls[0] || defaultSettings.radioStationUrl,
       radioStationUrls,
     };
@@ -1777,6 +1780,18 @@ export function App() {
   const footerTrack = isRadioPresentation || suppressLocalFooter ? null : currentTrack ?? lastPlayedTrack;
   const footerTrackCoverUrl = config && footerTrack ? buildCoverArtUrl(config, footerTrack.coverArt, "160") : null;
   const visualEffectsEnabled = !appSettings.lowPerformanceMode;
+  const personalPlaylists = useMemo(
+    () => libraryData.playlists
+      .filter((playlist) => !playlist.owner || playlist.owner.localeCompare(config?.username ?? "", undefined, { sensitivity: "accent" }) === 0)
+      .sort((a, b) => a.name.localeCompare(b.name)),
+    [config?.username, libraryData.playlists],
+  );
+  const sharedPlaylists = useMemo(
+    () => libraryData.playlists
+      .filter((playlist) => playlist.owner && playlist.owner.localeCompare(config?.username ?? "", undefined, { sensitivity: "accent" }) !== 0)
+      .sort((a, b) => a.name.localeCompare(b.name)),
+    [config?.username, libraryData.playlists],
+  );
   const coverWashUrl = appSettings.coverWashEnabled && visualEffectsEnabled
     ? isRadioPlaying
       ? radioCoverUrl
@@ -3745,10 +3760,8 @@ export function App() {
                 </DropdownMenu.Item>
                 {libraryData.playlists.length ? (
                   <div className="sidebar-playlist-menu-list">
-                    {libraryData.playlists
-                      .slice()
-                      .sort((a, b) => a.name.localeCompare(b.name))
-                      .map((playlist) => (
+                    {personalPlaylists.length ? <p className="sidebar-playlist-menu-heading">Your playlists</p> : null}
+                    {personalPlaylists.map((playlist) => (
                         <DropdownMenu.Item asChild key={playlist.id}>
                           <button
                             className={detailSelection?.type === "playlist" && detailSelection.data.id === playlist.id ? "active" : ""}
@@ -3763,6 +3776,24 @@ export function App() {
                           </button>
                         </DropdownMenu.Item>
                       ))}
+                    {appSettings.showSharedPlaylists && sharedPlaylists.length ? <>
+                      <p className="sidebar-playlist-menu-heading">Shared playlists</p>
+                      {sharedPlaylists.map((playlist) => (
+                        <DropdownMenu.Item asChild key={playlist.id}>
+                          <button
+                            className={detailSelection?.type === "playlist" && detailSelection.data.id === playlist.id ? "active" : ""}
+                            type="button"
+                            data-context-kind="playlist"
+                            data-context-id={playlist.id}
+                            onClick={() => void openPlaylist(playlist)}
+                          >
+                            <ListMusic size={15} />
+                            <span>{playlist.name}</span>
+                            <small>{getPlaylistMeta(playlist)}</small>
+                          </button>
+                        </DropdownMenu.Item>
+                      ))}
+                    </> : null}
                   </div>
                 ) : (
                   <p className="sidebar-playlist-menu-empty">No playlists yet.</p>
@@ -5288,6 +5319,14 @@ function SettingsView({
             <option value="list">List</option>
             <option value="art">Art</option>
           </select>
+        </label>
+        <label className="settings-checkbox">
+          <input
+            type="checkbox"
+            checked={appSettings.showSharedPlaylists}
+            onChange={(event) => updateAppSettings({ ...appSettings, showSharedPlaylists: event.target.checked })}
+          />
+          <span>Show shared playlists in the Playlists menu</span>
         </label>
       </section> : null}
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -521,7 +521,7 @@ h1 {
   z-index: 30;
   display: grid;
   gap: 6px;
-  width: 252px;
+  width: min(380px, calc(100vw - 24px));
   max-height: min(420px, calc(100vh - 24px));
   padding: 8px;
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -533,12 +533,12 @@ h1 {
 .sidebar-playlist-menu-all,
 .sidebar-playlist-menu-list button {
   display: grid;
-  grid-template-columns: 20px minmax(0, 1fr) auto;
-  align-items: center;
+  grid-template-columns: 20px minmax(0, 1fr) max-content;
+  align-items: start;
   gap: 8px;
   width: 100%;
   min-height: 36px;
-  padding: 0 9px;
+  padding: 8px 9px;
   border-radius: 7px;
   background: transparent;
   color: rgba(244, 241, 236, 0.78);
@@ -561,14 +561,27 @@ h1 {
   overflow: auto;
 }
 
-.sidebar-playlist-menu-list button span,
-.sidebar-playlist-menu-list button small {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.sidebar-playlist-menu-heading {
+  margin: 8px 9px 2px;
+  color: rgba(244, 241, 236, 0.46);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sidebar-playlist-menu-list button span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .sidebar-playlist-menu-list button small {
+  align-self: center;
+  max-width: 132px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: rgba(244, 241, 236, 0.42);
   font-size: 10px;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -531,9 +531,10 @@ h1 {
 }
 
 .sidebar-playlist-menu-all,
-.sidebar-playlist-menu-list button {
+.sidebar-playlist-menu-list button,
+.sidebar-playlist-menu-create {
   display: grid;
-  grid-template-columns: 20px minmax(0, 1fr) max-content;
+  grid-template-columns: 20px minmax(0, 1fr);
   align-items: start;
   gap: 8px;
   width: 100%;
@@ -570,27 +571,33 @@ h1 {
   text-transform: uppercase;
 }
 
-.sidebar-playlist-menu-list button span {
+.sidebar-playlist-menu-copy {
+  display: grid;
+  gap: 2px;
   min-width: 0;
   overflow-wrap: anywhere;
   white-space: normal;
 }
 
-.sidebar-playlist-menu-list button small {
-  align-self: center;
-  max-width: 132px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.sidebar-playlist-menu-copy strong {
+  color: inherit;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.sidebar-playlist-menu-copy small {
   color: rgba(244, 241, 236, 0.42);
   font-size: 10px;
+  line-height: 1.35;
 }
 
 .sidebar-playlist-menu-all:hover,
 .sidebar-playlist-menu-all:focus-visible,
 .sidebar-playlist-menu-list button:hover,
 .sidebar-playlist-menu-list button:focus-visible,
-.sidebar-playlist-menu-list button.active {
+.sidebar-playlist-menu-list button.active,
+.sidebar-playlist-menu-create:hover,
+.sidebar-playlist-menu-create:focus-visible {
   background: rgba(255, 255, 255, 0.1);
   color: #fff;
 }
@@ -599,6 +606,13 @@ h1 {
   padding: 10px 9px;
   color: rgba(244, 241, 236, 0.5);
   font-size: 12px;
+}
+
+.sidebar-playlist-menu-create {
+  margin-top: 2px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0 0 7px 7px;
+  color: #f0d27b;
 }
 
 .sidebar-actions {

--- a/src/styles.css
+++ b/src/styles.css
@@ -492,13 +492,6 @@ h1 {
   color: #fff;
 }
 
-.nav-parent-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 30px;
-  align-items: center;
-  gap: 4px;
-}
-
 .nav-item.nav-parent {
   min-width: 0;
 }
@@ -509,45 +502,90 @@ h1 {
   white-space: nowrap;
 }
 
-.nav-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
-  background: transparent;
-  color: rgba(244, 241, 236, 0.46);
-  cursor: pointer;
+.nav-playlist-trigger {
+  justify-content: flex-start;
 }
 
-.nav-toggle:hover,
-.nav-toggle:focus-visible,
-.nav-toggle.open {
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(244, 241, 236, 0.82);
-}
-
-.nav-playlist-list {
-  display: grid;
-  gap: 2px;
-  margin: -4px 0 4px 14px;
-  padding: 2px 0 2px 12px;
-  border-left: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-.nav-item.nav-playlist {
-  min-height: 28px;
-  margin-left: 0;
-  padding-left: 10px;
-  color: rgba(244, 241, 236, 0.48);
-  font-size: 11px;
-}
-
-.nav-playlist span {
+.nav-playlist-trigger > span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.nav-playlist-trigger > svg:last-child {
+  margin-left: auto;
+  color: rgba(244, 241, 236, 0.42);
+}
+
+.sidebar-playlist-menu {
+  z-index: 30;
+  display: grid;
+  gap: 6px;
+  width: 252px;
+  max-height: min(420px, calc(100vh - 24px));
+  padding: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  background: rgba(19, 19, 18, 0.98);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.52);
+}
+
+.sidebar-playlist-menu-all,
+.sidebar-playlist-menu-list button {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 36px;
+  padding: 0 9px;
+  border-radius: 7px;
+  background: transparent;
+  color: rgba(244, 241, 236, 0.78);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.sidebar-playlist-menu-all {
+  grid-template-columns: 20px minmax(0, 1fr);
+  color: #f0d27b;
+}
+
+.sidebar-playlist-menu-list {
+  display: grid;
+  gap: 2px;
+  max-height: 330px;
+  padding-top: 6px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: auto;
+}
+
+.sidebar-playlist-menu-list button span,
+.sidebar-playlist-menu-list button small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-playlist-menu-list button small {
+  color: rgba(244, 241, 236, 0.42);
+  font-size: 10px;
+}
+
+.sidebar-playlist-menu-all:hover,
+.sidebar-playlist-menu-all:focus-visible,
+.sidebar-playlist-menu-list button:hover,
+.sidebar-playlist-menu-list button:focus-visible,
+.sidebar-playlist-menu-list button.active {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.sidebar-playlist-menu-empty {
+  padding: 10px 9px;
+  color: rgba(244, 241, 236, 0.5);
+  font-size: 12px;
 }
 
 .sidebar-actions {

--- a/src/styles.css
+++ b/src/styles.css
@@ -521,7 +521,9 @@ h1 {
   z-index: 30;
   display: grid;
   gap: 6px;
-  width: min(380px, calc(100vw - 24px));
+  width: fit-content;
+  min-width: 280px;
+  max-width: min(420px, calc(100vw - 24px));
   max-height: min(420px, calc(100vh - 24px));
   padding: 8px;
   border: 1px solid rgba(255, 255, 255, 0.12);


### PR DESCRIPTION
## Summary

Makes playlists directly accessible from the sidebar without expanding a nested section.

## Changes

- Replace the sidebar Playlists collapse with an adaptive flyout.
- Show personal playlists first and shared playlists in a separate, optional section.
- Show shared-list owner, song count, and compact duration metadata.
- Support wrapped long names and a New playlist action in the flyout.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Preview served at `http://10.10.10.11:1420/` before the split.

## Rollback

Revert this PR's squash commit to restore the previous sidebar playlist behavior.
