### PR TITLE
feat: Let listeners resize and collapse the app sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3896,6 +3896,16 @@ export function App() {
             <Settings size={18} />
             Settings
           </button>
+          <button
+            className="player-panel-toggle sidebar-collapse-toggle"
+            type="button"
+            aria-label="Hide left sidebar"
+            aria-pressed={true}
+            title="Hide sidebar"
+            onClick={() => setSidebarCollapsedState(true)}
+          >
+            <PanelLeftClose size={17} />
+          </button>
         </div>
         <div
           className="sidebar-resize-handle"
@@ -4086,16 +4096,18 @@ export function App() {
           }}
         />
 
-        <button
-          className={`player-panel-toggle player-sidebar-toggle ${sidebarCollapsed ? "" : "active"}`}
-          type="button"
-          aria-label={sidebarCollapsed ? "Show left sidebar" : "Hide left sidebar"}
-          aria-pressed={!sidebarCollapsed}
-          title={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
-          onClick={() => setSidebarCollapsedState(!sidebarCollapsed)}
-        >
-          {sidebarCollapsed ? <PanelLeftOpen size={17} /> : <PanelLeftClose size={17} />}
-        </button>
+        {sidebarCollapsed ? (
+          <button
+            className="player-panel-toggle player-sidebar-toggle"
+            type="button"
+            aria-label="Show left sidebar"
+            aria-pressed={false}
+            title="Show sidebar"
+            onClick={() => setSidebarCollapsedState(false)}
+          >
+            <PanelLeftOpen size={17} />
+          </button>
+        ) : null}
         <div className={`now-playing ${footerTrack || isRadioPresentation ? "" : "empty"}`}>
           {isRadioPresentation ? (
             radioCoverUrl ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,8 @@ import {
   Mic2,
   Music2,
   Pause,
+  PanelLeftClose,
+  PanelLeftOpen,
   PanelRightClose,
   PanelRightOpen,
   Play,
@@ -371,6 +373,10 @@ const LISTENING_HISTORY_KEY = "prism-player.listeningHistory";
 const RIGHT_PANEL_OPEN_KEY = "prism-player.rightPanelOpen";
 const RIGHT_PANEL_TAB_KEY = "prism-player.rightPanelTab";
 const SIDEBAR_COLLAPSED_KEY = "prism-player.sidebarCollapsed";
+const SIDEBAR_WIDTH_KEY = "prism-player.sidebarWidth";
+const SIDEBAR_MIN_WIDTH = 208;
+const SIDEBAR_MAX_WIDTH = 360;
+const SIDEBAR_DEFAULT_WIDTH = 248;
 const INSTALL_ID_KEY = "prism-player.installId";
 const ANALYTICS_LAST_PING_KEY = "prism-player.analyticsLastPing";
 const PRISM_RELEASES_URL = "https://github.com/kylejschultz/prism-player/releases/latest";
@@ -749,6 +755,15 @@ function loadStoredBoolean(key: string, fallback: boolean) {
     const raw = localStorage.getItem(key);
     if (raw == null) return fallback;
     return raw === "true";
+  } catch {
+    return fallback;
+  }
+}
+
+function loadStoredNumber(key: string, fallback: number, min: number, max: number) {
+  try {
+    const value = Number(localStorage.getItem(key));
+    return Number.isFinite(value) ? clampNumber(value, min, max) : fallback;
   } catch {
     return fallback;
   }
@@ -1712,6 +1727,12 @@ export function App() {
   const [searchStatus, setSearchStatus] = useState<"idle" | "searching" | "error">("idle");
   const [searchFocused, setSearchFocused] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => loadStoredBoolean(SIDEBAR_COLLAPSED_KEY, false));
+  const [sidebarWidth, setSidebarWidth] = useState(() => loadStoredNumber(
+    SIDEBAR_WIDTH_KEY,
+    SIDEBAR_DEFAULT_WIDTH,
+    SIDEBAR_MIN_WIDTH,
+    SIDEBAR_MAX_WIDTH,
+  ));
   const [albumViewMode, setAlbumViewMode] = useState<AlbumViewMode>(() => loadStoredSettings().defaultAlbumView);
   const [artistViewMode, setArtistViewMode] = useState<ArtistViewMode>(() => loadStoredSettings().defaultArtistView);
   const [settingsTab, setSettingsTab] = useState<SettingsTab>("connection");
@@ -2150,6 +2171,39 @@ export function App() {
   function setSidebarCollapsedState(collapsed: boolean) {
     setSidebarCollapsed(collapsed);
     localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(collapsed));
+  }
+
+  function setSidebarWidthState(nextWidth: number) {
+    const width = clampNumber(nextWidth, SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH);
+    setSidebarWidth(width);
+    localStorage.setItem(SIDEBAR_WIDTH_KEY, String(width));
+  }
+
+  function beginSidebarResize(event: ReactPointerEvent<HTMLDivElement>) {
+    if (sidebarCollapsed) return;
+
+    event.preventDefault();
+    const initialWidth = sidebarWidth;
+    const startX = event.clientX;
+    let nextWidth = initialWidth;
+
+    document.body.classList.add("sidebar-resizing");
+
+    const handleMove = (moveEvent: PointerEvent) => {
+      nextWidth = clampNumber(initialWidth + moveEvent.clientX - startX, SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH);
+      setSidebarWidth(nextWidth);
+    };
+    const handleEnd = () => {
+      document.body.classList.remove("sidebar-resizing");
+      localStorage.setItem(SIDEBAR_WIDTH_KEY, String(nextWidth));
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", handleEnd);
+      window.removeEventListener("pointercancel", handleEnd);
+    };
+
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", handleEnd, { once: true });
+    window.addEventListener("pointercancel", handleEnd, { once: true });
   }
 
   function setAnalyticsConsent(enabled: boolean) {
@@ -3669,23 +3723,10 @@ export function App() {
       className={`app-shell ${rightPanelOpen ? "with-right-panel" : "right-panel-collapsed"} ${
         sidebarCollapsed ? "sidebar-collapsed" : ""
       } ${coverWashUrl ? "with-cover-wash" : ""}`}
+      style={{ "--sidebar-width": `${sidebarWidth}px` } as CSSProperties}
       onContextMenu={openLibraryContextMenu}
     >
       {coverWashUrl ? <div className="cover-wash-backdrop" style={{ backgroundImage: `url(${coverWashUrl})` }} aria-hidden="true" /> : null}
-
-      {sidebarCollapsed ? (
-        <div className="sidebar-rail sidebar-rail-left" aria-label="Collapsed sidebar">
-          <button
-            className="sidebar-edge-button sidebar-edge-button-left"
-            type="button"
-            aria-label="Show sidebar"
-            title="Show sidebar"
-            onClick={() => setSidebarCollapsedState(false)}
-          >
-            <ChevronRight size={18} />
-          </button>
-        </div>
-      ) : null}
 
       {!sidebarCollapsed ? <aside className="sidebar" aria-label="Primary navigation">
         <div className="brand">
@@ -3695,16 +3736,6 @@ export function App() {
             <h1>Player</h1>
           </div>
         </div>
-        <button
-          className="sidebar-edge-button sidebar-edge-button-left"
-          type="button"
-          aria-label="Hide sidebar"
-          title="Hide sidebar"
-          onClick={() => setSidebarCollapsedState(true)}
-        >
-          <ChevronLeft size={16} />
-        </button>
-
         <nav className="nav-list">
           <button
             className={`nav-item nav-home ${activeView === "overview" ? "active" : ""}`}
@@ -3866,6 +3897,35 @@ export function App() {
             Settings
           </button>
         </div>
+        <div
+          className="sidebar-resize-handle"
+          role="separator"
+          aria-label="Resize sidebar"
+          aria-orientation="vertical"
+          aria-valuemin={SIDEBAR_MIN_WIDTH}
+          aria-valuemax={SIDEBAR_MAX_WIDTH}
+          aria-valuenow={sidebarWidth}
+          tabIndex={0}
+          onPointerDown={beginSidebarResize}
+          onKeyDown={(event) => {
+            if (event.key === "ArrowLeft") {
+              event.preventDefault();
+              setSidebarWidthState(sidebarWidth - 16);
+            }
+            if (event.key === "ArrowRight") {
+              event.preventDefault();
+              setSidebarWidthState(sidebarWidth + 16);
+            }
+            if (event.key === "Home") {
+              event.preventDefault();
+              setSidebarWidthState(SIDEBAR_MIN_WIDTH);
+            }
+            if (event.key === "End") {
+              event.preventDefault();
+              setSidebarWidthState(SIDEBAR_MAX_WIDTH);
+            }
+          }}
+        />
       </aside> : null}
 
       <section className="workspace" aria-label="Music workspace">
@@ -4026,6 +4086,16 @@ export function App() {
           }}
         />
 
+        <button
+          className={`player-panel-toggle player-sidebar-toggle ${sidebarCollapsed ? "" : "active"}`}
+          type="button"
+          aria-label={sidebarCollapsed ? "Show left sidebar" : "Hide left sidebar"}
+          aria-pressed={!sidebarCollapsed}
+          title={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
+          onClick={() => setSidebarCollapsedState(!sidebarCollapsed)}
+        >
+          {sidebarCollapsed ? <PanelLeftOpen size={17} /> : <PanelLeftClose size={17} />}
+        </button>
         <div className={`now-playing ${footerTrack || isRadioPresentation ? "" : "empty"}`}>
           {isRadioPresentation ? (
             radioCoverUrl ? (

--- a/src/styles.css
+++ b/src/styles.css
@@ -93,7 +93,7 @@ textarea {
 .app-shell {
   position: relative;
   display: grid;
-  grid-template-columns: 212px minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-width, 248px) minmax(0, 1fr);
   grid-template-rows: minmax(0, 1fr) 94px;
   width: 100vw;
   height: 100vh;
@@ -137,23 +137,23 @@ textarea {
 }
 
 .app-shell.with-right-panel {
-  grid-template-columns: 212px minmax(0, 1fr) 338px;
+  grid-template-columns: var(--sidebar-width, 248px) minmax(0, 1fr) 338px;
 }
 
 .app-shell.right-panel-collapsed {
-  grid-template-columns: 212px minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-width, 248px) minmax(0, 1fr);
 }
 
 .app-shell.sidebar-collapsed {
-  grid-template-columns: 26px minmax(0, 1fr);
+  grid-template-columns: 0 minmax(0, 1fr);
 }
 
 .app-shell.sidebar-collapsed.with-right-panel {
-  grid-template-columns: 26px minmax(0, 1fr) 338px;
+  grid-template-columns: 0 minmax(0, 1fr) 338px;
 }
 
 .app-shell.sidebar-collapsed.right-panel-collapsed {
-  grid-template-columns: 26px minmax(0, 1fr);
+  grid-template-columns: 0 minmax(0, 1fr);
 }
 
 .sidebar {
@@ -167,6 +167,48 @@ textarea {
   border-right: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(12, 12, 12, 0.56);
   backdrop-filter: blur(24px);
+}
+
+.sidebar-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -4px;
+  bottom: 0;
+  z-index: 8;
+  width: 8px;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.sidebar-resize-handle::after {
+  position: absolute;
+  top: 50%;
+  left: 2px;
+  width: 2px;
+  height: 42px;
+  border-radius: 999px;
+  background: rgba(244, 241, 236, 0.34);
+  content: "";
+  opacity: 0;
+  transform: translateY(-50%);
+  transition: opacity 160ms ease, background 160ms ease;
+}
+
+.sidebar:hover .sidebar-resize-handle::after,
+.sidebar-resize-handle:focus-visible::after,
+body.sidebar-resizing .sidebar-resize-handle::after {
+  opacity: 1;
+}
+
+.sidebar-resize-handle:focus-visible::after,
+body.sidebar-resizing .sidebar-resize-handle::after {
+  background: #f8df91;
+}
+
+body.sidebar-resizing,
+body.sidebar-resizing * {
+  cursor: col-resize !important;
+  user-select: none;
 }
 
 .brand {
@@ -3499,6 +3541,18 @@ button.similar-chip:hover,
   backdrop-filter: blur(20px);
 }
 
+.player-sidebar-toggle {
+  position: absolute;
+  top: 50%;
+  left: 18px;
+  z-index: 2;
+  transform: translateY(-50%);
+}
+
+.player-sidebar-toggle + .now-playing {
+  padding-left: 42px;
+}
+
 .player-bar audio {
   display: none;
 }
@@ -4476,27 +4530,27 @@ button.similar-chip:hover,
   }
 
   .app-shell {
-    grid-template-columns: 188px minmax(0, 1fr);
+    grid-template-columns: min(var(--sidebar-width, 248px), 188px) minmax(0, 1fr);
   }
 
   .app-shell.with-right-panel {
-    grid-template-columns: 188px minmax(0, 1fr) 300px;
+    grid-template-columns: min(var(--sidebar-width, 248px), 188px) minmax(0, 1fr) 300px;
   }
 
   .app-shell.right-panel-collapsed {
-    grid-template-columns: 188px minmax(0, 1fr);
+    grid-template-columns: min(var(--sidebar-width, 248px), 188px) minmax(0, 1fr);
   }
 
   .app-shell.sidebar-collapsed {
-    grid-template-columns: 26px minmax(0, 1fr);
+    grid-template-columns: 0 minmax(0, 1fr);
   }
 
   .app-shell.sidebar-collapsed.with-right-panel {
-    grid-template-columns: 26px minmax(0, 1fr) 300px;
+    grid-template-columns: 0 minmax(0, 1fr) 300px;
   }
 
   .app-shell.sidebar-collapsed.right-panel-collapsed {
-    grid-template-columns: 26px minmax(0, 1fr);
+    grid-template-columns: 0 minmax(0, 1fr);
   }
 
   .sidebar {
@@ -4600,27 +4654,27 @@ button.similar-chip:hover,
   }
 
   .app-shell {
-    grid-template-columns: 172px minmax(0, 1fr);
+    grid-template-columns: min(var(--sidebar-width, 248px), 172px) minmax(0, 1fr);
   }
 
   .app-shell.with-right-panel {
-    grid-template-columns: 172px minmax(0, 1fr) 280px;
+    grid-template-columns: min(var(--sidebar-width, 248px), 172px) minmax(0, 1fr) 280px;
   }
 
   .app-shell.right-panel-collapsed {
-    grid-template-columns: 172px minmax(0, 1fr);
+    grid-template-columns: min(var(--sidebar-width, 248px), 172px) minmax(0, 1fr);
   }
 
   .app-shell.sidebar-collapsed {
-    grid-template-columns: 26px minmax(0, 1fr);
+    grid-template-columns: 0 minmax(0, 1fr);
   }
 
   .app-shell.sidebar-collapsed.with-right-panel {
-    grid-template-columns: 26px minmax(0, 1fr) 280px;
+    grid-template-columns: 0 minmax(0, 1fr) 280px;
   }
 
   .app-shell.sidebar-collapsed.right-panel-collapsed {
-    grid-template-columns: 26px minmax(0, 1fr);
+    grid-template-columns: 0 minmax(0, 1fr);
   }
 
   .brand-mark {

--- a/src/styles.css
+++ b/src/styles.css
@@ -660,15 +660,21 @@ h1 {
 }
 
 .sidebar-actions {
-  display: grid;
+  display: flex;
+  align-items: center;
   gap: 6px;
   margin-top: auto;
   padding-top: 12px;
 }
 
 .sidebar-settings {
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   color: rgba(244, 241, 236, 0.66);
+}
+
+.sidebar-collapse-toggle {
+  flex: 0 0 auto;
 }
 
 .workspace {


### PR DESCRIPTION
## Summary

- Adds a footer control for the left sidebar that mirrors the existing right-panel control.
- Lets listeners resize the expanded sidebar from 208px to 360px, with the choice persisted locally.
- Keeps narrow-window layouts bounded and supports keyboard resizing with arrow, Home, and End keys.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Preview running from this branch at `http://10.10.10.11:1420/`

## Rollback

Revert this PR to restore the fixed-width sidebar and its previous edge collapse control.
