### PR TITLE
feat: Make Home a music discovery dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1193,11 +1193,29 @@ function splitFeaturedTitle(title: string) {
   }
 
   const liveSuffix = title.match(/\s+(?:[-–—]\s*)?((?:live)(?:\s+(?:at|from|in)\b)?.+)$/i);
-  if (!liveSuffix?.index) return { main: title, feature: "" };
+  if (liveSuffix?.index) {
+    return {
+      main: title.slice(0, liveSuffix.index).trim(),
+      feature: liveSuffix[1]?.trim() ?? "",
+    };
+  }
+
+  const parentheticalSuffix = title.match(/\s+((?:\([^)]*\)\s*)+)$/);
+  if (parentheticalSuffix?.index) {
+    const qualifiers = [...parentheticalSuffix[1].matchAll(/\(([^)]*)\)/g)]
+      .map((match) => match[1]?.trim())
+      .filter((qualifier): qualifier is string => Boolean(qualifier));
+    if (qualifiers.length) {
+      return {
+        main: title.slice(0, parentheticalSuffix.index).trim(),
+        feature: qualifiers.join(" · "),
+      };
+    }
+  }
 
   return {
-    main: title.slice(0, liveSuffix.index).trim(),
-    feature: liveSuffix[1]?.trim() ?? "",
+    main: title,
+    feature: "",
   };
 }
 
@@ -6007,7 +6025,7 @@ function RadioView({
 
         <div className="radio-copy">
           <p className="eyebrow">Now Playing{listenerCount == null ? "" : ` / ${listenerCount} listener${listenerCount === 1 ? "" : "s"}`}</p>
-          <h3>
+          <h3 aria-label={radioTitle}>
             <span>{radioTitleParts.main}</span>
             {radioTitleParts.feature ? <em>{radioTitleParts.feature}</em> : null}
           </h3>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4109,7 +4109,6 @@ export function App() {
               setPlaylistCreatorOpen={setPlaylistCreatorOpen}
               onSongContextMenu={openSongContextMenu}
               onRetryLibrary={() => void refreshLibrary()}
-              onSelectLibraryView={selectView}
               detailSelection={detailSelection}
               detailStatus={detailStatus}
               detailMessage={detailMessage}
@@ -6033,7 +6032,6 @@ function LibraryView({
   searchStatus,
   setPlaylistCreatorOpen,
   onSongContextMenu,
-  onSelectLibraryView,
   detailSelection,
   detailStatus,
   detailMessage,
@@ -6102,7 +6100,6 @@ function LibraryView({
   searchStatus: "idle" | "searching" | "error";
   setPlaylistCreatorOpen: (open: boolean) => void;
   onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
-  onSelectLibraryView: (view: View) => void;
   detailSelection: DetailSelection;
   detailStatus: "idle" | "loading" | "error";
   detailMessage: string;
@@ -6246,25 +6243,17 @@ function LibraryView({
           {activeView === "overview" ? (
             <OverviewHome
               config={config}
-              recentAlbums={recentAlbums}
-              recentlyPlayedAlbums={recentlyPlayedAlbums}
               currentTrack={currentTrack}
               currentTrackCoverUrl={currentTrackCoverUrl}
               isPlaying={isPlaying}
               position={position}
               duration={duration}
-              favoriteIds={favoriteIds}
-              favoriteBusyKey={favoriteBusyKey}
-              onToggleFavorite={onToggleFavorite}
               hasPrevious={hasPrevious}
               hasNext={hasNext}
               onTogglePlayback={onTogglePlayback}
               onPrevious={onPrevious}
               onNext={onNext}
               onSeek={onSeek}
-              onSelectLibraryView={onSelectLibraryView}
-              onOpenAlbum={onOpenAlbum}
-              onPlayAlbum={onPlayAlbum}
             />
           ) : null}
           {activeView === "albums" ? (
@@ -6375,71 +6364,36 @@ function LibraryView({
 
 function OverviewHome({
   config,
-  recentAlbums,
-  recentlyPlayedAlbums,
   currentTrack,
   currentTrackCoverUrl,
   isPlaying,
   position,
   duration,
-  favoriteIds,
-  favoriteBusyKey,
-  onToggleFavorite,
   hasPrevious,
   hasNext,
   onTogglePlayback,
   onPrevious,
   onNext,
   onSeek,
-  onSelectLibraryView,
-  onOpenAlbum,
-  onPlayAlbum,
 }: {
   config: NavidromeConfig | null;
-  recentAlbums: Album[];
-  recentlyPlayedAlbums: Album[];
   currentTrack: Song | null;
   currentTrackCoverUrl: string | null;
   isPlaying: boolean;
   position: number;
   duration: number;
-  favoriteIds: FavoriteIds;
-  favoriteBusyKey: string;
-  onToggleFavorite: (kind: FavoriteKind, id: string, favorite: boolean) => void;
   hasPrevious: boolean;
   hasNext: boolean;
   onTogglePlayback: () => void;
   onPrevious: () => void;
   onNext: () => void;
   onSeek: (position: number) => void;
-  onSelectLibraryView: (view: View) => void;
-  onOpenAlbum: (album: Album) => void;
-  onPlayAlbum: (album: Album) => void;
 }) {
-  const visualAlbums = (recentlyPlayedAlbums.length ? recentlyPlayedAlbums : recentAlbums).slice(0, 8);
   const hasTrack = Boolean(currentTrack);
   const progress = Math.min(position, Math.max(duration, 1));
 
   return (
     <div className="home-view">
-      <section className="home-listening-ribbon" aria-labelledby="recent-listening-title">
-        <div className="section-label">
-          <div>
-            <p className="eyebrow">Your listening</p>
-            <h4 id="recent-listening-title">Recently played</h4>
-          </div>
-          <button className="detail-back" type="button" onClick={() => onSelectLibraryView("recentlyPlayed")}>View history</button>
-        </div>
-        <div className="home-art-ribbon">
-          {visualAlbums.map((album) => (
-            <button className="home-ribbon-album" type="button" key={album.id} onClick={() => onOpenAlbum(album)} aria-label={`Open ${album.name}`}>
-              <CoverArt src={config ? buildCoverArtUrl(config, album.coverArt, "240") : null} label={album.name} className="home-ribbon-cover" />
-            </button>
-          ))}
-          {!visualAlbums.length ? <p className="home-ribbon-empty">Play something to make this home feel like yours.</p> : null}
-        </div>
-      </section>
-
       <section className={`home-now-playing-hero ${hasTrack ? "has-track" : ""}`}>
         <div className="home-now-playing-art">
           <CoverArt src={currentTrackCoverUrl} label={currentTrack?.title ?? "Prism Player"} className="home-now-playing-cover" />
@@ -6461,28 +6415,6 @@ function OverviewHome({
             <span>{formatDuration(duration)}</span>
           </div>
         </div>
-      </section>
-
-      <section>
-        <div className="section-label">
-          <div>
-            <p className="eyebrow">Fresh in your library</p>
-            <h4>Recently added</h4>
-          </div>
-          <button className="detail-back" type="button" onClick={() => onSelectLibraryView("recentlyAdded")}>
-            View albums
-          </button>
-        </div>
-        <AlbumGrid
-          config={config}
-          albums={recentAlbums}
-          favoriteIds={favoriteIds}
-          favoriteBusyKey={favoriteBusyKey}
-          onToggleFavorite={onToggleFavorite}
-          onOpenAlbum={onOpenAlbum}
-          onPlayAlbum={onPlayAlbum}
-          withAlphabetRail={false}
-        />
       </section>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6491,14 +6491,14 @@ function OverviewHome({
   const hour = new Date().getHours();
   const greeting = hour < 12 ? "Good morning" : hour < 18 ? "Good afternoon" : "Good evening";
   const listenerName = config?.name.trim();
-  const visibleRecentAlbums = recentlyPlayedAlbums.slice(0, 5);
-  const visibleNewAlbums = recentAlbums.slice(0, 5);
+  const visibleRecentAlbums = recentlyPlayedAlbums.slice(0, 3);
+  const visibleNewAlbums = recentAlbums.slice(0, 3);
 
   useEffect(() => {
-    setShuffleAlbums(shuffled(albums).slice(0, 5));
+    setShuffleAlbums(shuffled(albums).slice(0, 3));
   }, [albums]);
 
-  const refreshShuffleAlbums = () => setShuffleAlbums(shuffled(albums).slice(0, 5));
+  const refreshShuffleAlbums = () => setShuffleAlbums(shuffled(albums).slice(0, 3));
 
   return (
     <div className="home-dashboard">
@@ -6541,15 +6541,16 @@ function OverviewHome({
           {isRadioStarting ? "Tuning in" : `Listen to ${radioStationName}`}
         </button>
       </section>
-      <HomeAlbumShelf title="Recently played" albums={visibleRecentAlbums} config={config} onPlayAlbum={onPlayAlbum} onOpenAlbum={() => onSelectView("recentlyPlayed")} />
-      <HomeAlbumShelf title="Recently added" albums={visibleNewAlbums} config={config} onPlayAlbum={onPlayAlbum} onOpenAlbum={() => onSelectView("recentlyAdded")} />
-      <HomeAlbumShelf title="Shuffle something" albums={shuffleAlbums} config={config} onPlayAlbum={onPlayAlbum} onRefresh={refreshShuffleAlbums} />
+      <HomeAlbumShelf title="Recently played" description="A few records to come back to." albums={visibleRecentAlbums} config={config} onPlayAlbum={onPlayAlbum} onOpenAlbum={() => onSelectView("recentlyPlayed")} />
+      <HomeAlbumShelf title="Recently added" description="Fresh additions to your library." albums={visibleNewAlbums} config={config} onPlayAlbum={onPlayAlbum} onOpenAlbum={() => onSelectView("recentlyAdded")} />
+      <HomeAlbumShelf title="Start listening" description="A few picks from your library." albums={shuffleAlbums} config={config} onPlayAlbum={onPlayAlbum} onRefresh={refreshShuffleAlbums} />
     </div>
   );
 }
 
 function HomeAlbumShelf({
   title,
+  description,
   albums,
   config,
   onPlayAlbum,
@@ -6557,6 +6558,7 @@ function HomeAlbumShelf({
   onRefresh,
 }: {
   title: string;
+  description: string;
   albums: Album[];
   config: NavidromeConfig | null;
   onPlayAlbum: (album: Album) => void;
@@ -6568,7 +6570,10 @@ function HomeAlbumShelf({
   return (
     <section className="home-album-shelf">
       <div className="home-shelf-heading">
-        <h4>{title}</h4>
+        <div>
+          <h4>{title}</h4>
+          <p>{description}</p>
+        </div>
         {onRefresh ? <button className="home-shelf-action" type="button" onClick={onRefresh}><RefreshCw size={15} /> Refresh</button> : null}
         {onOpenAlbum ? <button className="home-shelf-action" type="button" onClick={onOpenAlbum}>See all <ChevronRight size={15} /></button> : null}
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6581,6 +6581,28 @@ function HomeAlbumShelf({
   onOpenAlbum?: () => void;
   onRefresh?: () => void;
 }) {
+  const rowRef = useRef<HTMLDivElement>(null);
+  const [scrollMetrics, setScrollMetrics] = useState({ max: 0, value: 0 });
+
+  useEffect(() => {
+    const row = rowRef.current;
+    if (!row) return;
+
+    const updateScrollMetrics = () => {
+      const max = Math.max(0, row.scrollWidth - row.clientWidth);
+      setScrollMetrics({ max, value: Math.min(row.scrollLeft, max) });
+    };
+
+    updateScrollMetrics();
+    row.addEventListener("scroll", updateScrollMetrics, { passive: true });
+    const resizeObserver = new ResizeObserver(updateScrollMetrics);
+    resizeObserver.observe(row);
+    return () => {
+      row.removeEventListener("scroll", updateScrollMetrics);
+      resizeObserver.disconnect();
+    };
+  }, [albums]);
+
   if (!albums.length) return null;
 
   return (
@@ -6593,21 +6615,35 @@ function HomeAlbumShelf({
         {onRefresh ? <button className="home-shelf-action" type="button" onClick={onRefresh}><RefreshCw size={15} /> Refresh</button> : null}
         {onOpenAlbum ? <button className="home-shelf-action" type="button" onClick={onOpenAlbum}>See all <ChevronRight size={15} /></button> : null}
       </div>
-      <div className="home-album-row" tabIndex={0} aria-label={`${title} albums`}>
-        {albums.map((album) => (
-          <div className="home-album" key={album.id}>
-            <PlayableCover
-              src={config ? buildCoverArtUrl(config, album.coverArt, "320") : null}
-              label={album.name}
-              className="home-album-cover"
-              onPlay={() => onPlayAlbum(album)}
-            />
-            <div className="home-album-copy">
-              <strong>{album.name}</strong>
-              <small>{album.artist || `${album.songCount ?? 0} tracks`}</small>
+      <div className="home-album-carousel">
+        <div className="home-album-row" ref={rowRef} tabIndex={0} aria-label={`${title} albums`}>
+          {albums.map((album) => (
+            <div className="home-album" key={album.id}>
+              <PlayableCover
+                src={config ? buildCoverArtUrl(config, album.coverArt, "320") : null}
+                label={album.name}
+                className="home-album-cover"
+                onPlay={() => onPlayAlbum(album)}
+              />
+              <div className="home-album-copy">
+                <strong>{album.name}</strong>
+                <small>{album.artist || `${album.songCount ?? 0} tracks`}</small>
+              </div>
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
+        {scrollMetrics.max > 0 ? (
+          <input
+            className="home-album-scrollbar"
+            type="range"
+            min="0"
+            max={scrollMetrics.max}
+            value={scrollMetrics.value}
+            step="1"
+            aria-label={`Scroll ${title} albums`}
+            onChange={(event) => rowRef.current?.scrollTo({ left: Number(event.currentTarget.value) })}
+          />
+        ) : null}
       </div>
     </section>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6471,6 +6471,7 @@ function OverviewHome({
   const [shuffleAlbums, setShuffleAlbums] = useState<Album[]>([]);
   const hour = new Date().getHours();
   const greeting = hour < 12 ? "Good morning" : hour < 18 ? "Good afternoon" : "Good evening";
+  const listenerName = config?.username.trim();
   const visibleRecentAlbums = recentlyPlayedAlbums.slice(0, 5);
   const visibleNewAlbums = recentAlbums.slice(0, 5);
 
@@ -6485,7 +6486,7 @@ function OverviewHome({
       <section className="home-dashboard-intro">
         <div>
           <p className="eyebrow">Your listening</p>
-          <h3>{greeting}.</h3>
+          <h3>{greeting}{listenerName ? `, ${listenerName}` : ""}.</h3>
           <p>{latestListen ? `Pick up where you left off with ${latestListen.title}${latestListen.artist ? ` by ${latestListen.artist}` : ""}.` : config ? "Start a record, and Prism will keep the good stuff close at hand." : "Connect your library to make this space yours."}</p>
           {latestListen ? (
             isContinuing ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4094,6 +4094,7 @@ export function App() {
               recentAlbums={libraryData.recentAlbums}
               recentlyPlayedAlbums={libraryData.recentlyPlayedAlbums}
               listeningHistory={listeningHistory}
+              onSelectView={selectView}
               onClearListeningHistory={clearListeningHistory}
               songs={songLibrary}
               songLibraryStatus={songLibraryStatus}
@@ -6021,6 +6022,7 @@ function LibraryView({
   recentAlbums,
   recentlyPlayedAlbums,
   listeningHistory,
+  onSelectView,
   onClearListeningHistory,
   songs,
   songLibraryStatus,
@@ -6089,6 +6091,7 @@ function LibraryView({
   recentAlbums: Album[];
   recentlyPlayedAlbums: Album[];
   listeningHistory: ListeningHistoryEntry[];
+  onSelectView: (view: View) => void;
   onClearListeningHistory: () => void;
   songs: Song[];
   songLibraryStatus: "idle" | "loading" | "ready" | "error";
@@ -6250,9 +6253,13 @@ function LibraryView({
           {activeView === "overview" ? (
             <OverviewHome
               config={config}
+              albums={albums}
+              recentAlbums={recentAlbums}
               recentlyPlayedAlbums={recentlyPlayedAlbums}
               listeningHistory={listeningHistory}
               onPlaySong={onPlaySong}
+              onPlayAlbum={onPlayAlbum}
+              onSelectView={onSelectView}
             />
           ) : null}
           {activeView === "nowPlaying" ? (
@@ -6379,25 +6386,43 @@ function LibraryView({
 
 function OverviewHome({
   config,
+  albums,
+  recentAlbums,
   recentlyPlayedAlbums,
   listeningHistory,
   onPlaySong,
+  onPlayAlbum,
+  onSelectView,
 }: {
   config: NavidromeConfig | null;
+  albums: Album[];
+  recentAlbums: Album[];
   recentlyPlayedAlbums: Album[];
   listeningHistory: ListeningHistoryEntry[];
   onPlaySong: (song: Song) => void;
+  onPlayAlbum: (album: Album) => void;
+  onSelectView: (view: View) => void;
 }) {
-  const artAlbums = recentlyPlayedAlbums.slice(0, 5);
   const latestListen = listeningHistory[0]?.song;
+  const [shuffleAlbums, setShuffleAlbums] = useState<Album[]>([]);
+  const hour = new Date().getHours();
+  const greeting = hour < 12 ? "Good morning" : hour < 18 ? "Good afternoon" : "Good evening";
+  const visibleRecentAlbums = recentlyPlayedAlbums.slice(0, 5);
+  const visibleNewAlbums = recentAlbums.slice(0, 5);
+
+  useEffect(() => {
+    setShuffleAlbums(shuffled(albums).slice(0, 5));
+  }, [albums]);
+
+  const refreshShuffleAlbums = () => setShuffleAlbums(shuffled(albums).slice(0, 5));
 
   return (
     <div className="home-dashboard">
       <section className="home-dashboard-intro">
         <div>
           <p className="eyebrow">Your listening</p>
-          <h3>Music, close at hand.</h3>
-          <p>{latestListen ? `Last played: ${latestListen.title}${latestListen.artist ? ` by ${latestListen.artist}` : ""}` : config ? "Start a record, and Prism will keep your recent listening here." : "Connect your library to make this space yours."}</p>
+          <h3>{greeting}.</h3>
+          <p>{latestListen ? `Pick up where you left off with ${latestListen.title}${latestListen.artist ? ` by ${latestListen.artist}` : ""}.` : config ? "Start a record, and Prism will keep the good stuff close at hand." : "Connect your library to make this space yours."}</p>
           {latestListen ? (
             <button className="connect-button home-continue-button" type="button" onClick={() => onPlaySong(latestListen)}>
               <Play size={16} fill="currentColor" />
@@ -6405,8 +6430,8 @@ function OverviewHome({
             </button>
           ) : null}
         </div>
-        <div className="home-art-cluster" aria-label="Recently played albums">
-          {artAlbums.length ? artAlbums.map((album, index) => (
+        <div className="home-art-cluster" aria-label="Albums from your library">
+          {visibleRecentAlbums.length ? visibleRecentAlbums.map((album, index) => (
             <CoverArt
               key={album.id}
               src={config ? buildCoverArtUrl(config, album.coverArt, "320") : null}
@@ -6416,7 +6441,63 @@ function OverviewHome({
           )) : <div className="home-cluster-empty"><Music2 size={34} /></div>}
         </div>
       </section>
+      <section className="home-radio-card">
+        <div className="home-radio-mark"><RadioTower size={22} /></div>
+        <div>
+          <p className="eyebrow">Live from Subwave</p>
+          <h4>Listen to Radio</h4>
+          <p>A separate place for the live station, shows, and requests.</p>
+        </div>
+        <button className="secondary-button home-radio-button" type="button" onClick={() => onSelectView("radio")}>
+          Open Radio <ChevronRight size={16} />
+        </button>
+      </section>
+      <HomeAlbumShelf title="Recently played" albums={visibleRecentAlbums} config={config} onPlayAlbum={onPlayAlbum} onOpenAlbum={() => onSelectView("recentlyPlayed")} />
+      <HomeAlbumShelf title="Recently added" albums={visibleNewAlbums} config={config} onPlayAlbum={onPlayAlbum} onOpenAlbum={() => onSelectView("recentlyAdded")} />
+      <HomeAlbumShelf title="Shuffle something" albums={shuffleAlbums} config={config} onPlayAlbum={onPlayAlbum} onRefresh={refreshShuffleAlbums} />
     </div>
+  );
+}
+
+function HomeAlbumShelf({
+  title,
+  albums,
+  config,
+  onPlayAlbum,
+  onOpenAlbum,
+  onRefresh,
+}: {
+  title: string;
+  albums: Album[];
+  config: NavidromeConfig | null;
+  onPlayAlbum: (album: Album) => void;
+  onOpenAlbum?: () => void;
+  onRefresh?: () => void;
+}) {
+  if (!albums.length) return null;
+
+  return (
+    <section className="home-album-shelf">
+      <div className="home-shelf-heading">
+        <h4>{title}</h4>
+        {onRefresh ? <button className="home-shelf-action" type="button" onClick={onRefresh}><RefreshCw size={15} /> Refresh</button> : null}
+        {onOpenAlbum ? <button className="home-shelf-action" type="button" onClick={onOpenAlbum}>See all <ChevronRight size={15} /></button> : null}
+      </div>
+      <div className="home-album-row">
+        {albums.map((album) => (
+          <div className="home-album" key={album.id}>
+            <PlayableCover
+              src={config ? buildCoverArtUrl(config, album.coverArt, "320") : null}
+              label={album.name}
+              className="home-album-cover"
+              onPlay={() => onPlayAlbum(album)}
+            />
+            <strong>{album.name}</strong>
+            <small>{album.artist || `${album.songCount ?? 0} tracks`}</small>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6397,6 +6397,9 @@ function OverviewHome({
   return (
     <div className="home-view">
       <section className={`home-now-playing-hero ${hasTrack ? "has-track" : ""}`}>
+        {currentTrackCoverUrl ? (
+          <div className="home-cover-wash" style={{ backgroundImage: `url(${currentTrackCoverUrl})` }} aria-hidden="true" />
+        ) : null}
         <div className="home-now-playing-art">
           <CoverArt src={currentTrackCoverUrl} label={currentTrack?.title ?? "Prism Player"} className="home-now-playing-cover" />
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6165,7 +6165,7 @@ function LibraryView({
   const showLibraryError = libraryStatus === "error" && activeView !== "search";
 
   return (
-    <section className="browser-panel">
+    <section className={`browser-panel ${activeView === "overview" ? "home-panel" : ""}`}>
       {detailStatus !== "idle" || detailSelection ? (
         <DetailPanel
           config={config}
@@ -6194,9 +6194,10 @@ function LibraryView({
         />
       ) : (
         <>
-          <div className="panel-heading browser-heading">
-            <h3>{panelTitle}</h3>
-            <div className="heading-actions">
+          {activeView !== "overview" ? (
+            <div className="panel-heading browser-heading">
+              <h3>{panelTitle}</h3>
+              <div className="heading-actions">
               {activeView === "albums" ? (
                 <div className="view-toggle" aria-label="Album view">
                   <button className={albumViewMode === "art" ? "active" : ""} type="button" onClick={() => setAlbumViewMode("art")}>
@@ -6223,8 +6224,9 @@ function LibraryView({
                   New Playlist
                 </button>
               ) : null}
+              </div>
             </div>
-          </div>
+          ) : null}
           {showLibraryError ? (
             <StateNotice
               tone="bad"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6602,8 +6602,10 @@ function HomeAlbumShelf({
               className="home-album-cover"
               onPlay={() => onPlayAlbum(album)}
             />
-            <strong>{album.name}</strong>
-            <small>{album.artist || `${album.songCount ?? 0} tracks`}</small>
+            <div className="home-album-copy">
+              <strong>{album.name}</strong>
+              <small>{album.artist || `${album.songCount ?? 0} tracks`}</small>
+            </div>
           </div>
         ))}
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6581,6 +6581,31 @@ function HomeAlbumShelf({
   onOpenAlbum?: () => void;
   onRefresh?: () => void;
 }) {
+  const rowRef = useRef<HTMLDivElement>(null);
+  const [scrollCue, setScrollCue] = useState({ canScrollLeft: false, canScrollRight: false });
+
+  useEffect(() => {
+    const row = rowRef.current;
+    if (!row) return;
+
+    const updateScrollCue = () => {
+      const maxScrollLeft = Math.max(0, row.scrollWidth - row.clientWidth);
+      setScrollCue({
+        canScrollLeft: row.scrollLeft > 1,
+        canScrollRight: row.scrollLeft < maxScrollLeft - 1,
+      });
+    };
+
+    updateScrollCue();
+    row.addEventListener("scroll", updateScrollCue, { passive: true });
+    const resizeObserver = new ResizeObserver(updateScrollCue);
+    resizeObserver.observe(row);
+    return () => {
+      row.removeEventListener("scroll", updateScrollCue);
+      resizeObserver.disconnect();
+    };
+  }, [albums]);
+
   if (!albums.length) return null;
 
   return (
@@ -6594,7 +6619,7 @@ function HomeAlbumShelf({
         {onOpenAlbum ? <button className="home-shelf-action" type="button" onClick={onOpenAlbum}>See all <ChevronRight size={15} /></button> : null}
       </div>
       <div className="home-album-carousel">
-        <div className="home-album-row" tabIndex={0} aria-label={`${title} albums`}>
+        <div className="home-album-row" ref={rowRef} tabIndex={0} aria-label={`${title} albums`}>
           {albums.map((album) => (
             <div className="home-album" key={album.id}>
               <PlayableCover
@@ -6610,6 +6635,8 @@ function HomeAlbumShelf({
             </div>
           ))}
         </div>
+        {scrollCue.canScrollLeft ? <ChevronLeft className="home-album-scroll-cue home-album-scroll-cue-left" size={18} aria-hidden="true" /> : null}
+        {scrollCue.canScrollRight ? <ChevronRight className="home-album-scroll-cue home-album-scroll-cue-right" size={18} aria-hidden="true" /> : null}
       </div>
     </section>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,6 +108,7 @@ function isTauriDesktopApp() {
 
 type NavidromeConfig = {
   serverUrl: string;
+  name: string;
   username: string;
   password: string;
 };
@@ -412,6 +413,7 @@ const idleRadioWaveformBars = Array.from({ length: RADIO_WAVEFORM_BAR_COUNT }, (
 
 const emptyConfig: NavidromeConfig = {
   serverUrl: "",
+  name: "",
   username: "",
   password: "",
 };
@@ -550,7 +552,7 @@ function loadStoredConfig(): NavidromeConfig | null {
     if (!raw) return null;
     const parsed = JSON.parse(raw) as NavidromeConfig;
     if (!parsed.serverUrl || !parsed.username || !parsed.password) return null;
-    return parsed;
+    return { ...parsed, name: typeof parsed.name === "string" ? parsed.name : "" };
   } catch {
     return null;
   }
@@ -2313,6 +2315,7 @@ export function App() {
 
     const nextConfig = {
       serverUrl: normalizeServerUrl(form.serverUrl),
+      name: form.name.trim(),
       username: form.username.trim(),
       password: form.password,
     };
@@ -5389,6 +5392,16 @@ function SettingsView({
         </label>
 
         <label>
+          Name
+          <input
+            value={form.name}
+            onChange={(event) => setForm({ ...form, name: event.target.value })}
+            placeholder="Kyle"
+            autoComplete="name"
+          />
+        </label>
+
+        <label>
           Username
           <input
             value={form.username}
@@ -5677,6 +5690,12 @@ function FirstRunWizard({
             onChange={(event) => setForm({ ...form, serverUrl: event.target.value })}
             placeholder="https://music.example.com"
             autoComplete="url"
+          />
+          <input
+            value={form.name}
+            onChange={(event) => setForm({ ...form, name: event.target.value })}
+            placeholder="Name"
+            autoComplete="name"
           />
           <div className="split-inputs">
             <input
@@ -6471,7 +6490,7 @@ function OverviewHome({
   const [shuffleAlbums, setShuffleAlbums] = useState<Album[]>([]);
   const hour = new Date().getHours();
   const greeting = hour < 12 ? "Good morning" : hour < 18 ? "Good afternoon" : "Good evening";
-  const listenerName = config?.username.trim();
+  const listenerName = config?.name.trim();
   const visibleRecentAlbums = recentlyPlayedAlbums.slice(0, 5);
   const visibleNewAlbums = recentAlbums.slice(0, 5);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4089,6 +4089,10 @@ export function App() {
               radioMessage={radioMessage}
               radioWaveformBars={radioWaveformBars}
               tuneInRadio={tuneInRadio}
+              onStartRadio={() => {
+                selectView("radio");
+                void tuneInRadio();
+              }}
               onAddFirstRadioStation={tuneInRadio}
               albums={libraryData.albums}
               recentAlbums={libraryData.recentAlbums}
@@ -6017,6 +6021,7 @@ function LibraryView({
   radioMessage,
   radioWaveformBars,
   tuneInRadio,
+  onStartRadio,
   onAddFirstRadioStation,
   albums,
   recentAlbums,
@@ -6086,6 +6091,7 @@ function LibraryView({
   radioMessage: string;
   radioWaveformBars: number[];
   tuneInRadio: () => Promise<void>;
+  onStartRadio: () => void;
   onAddFirstRadioStation: (stationUrl: string) => Promise<void>;
   albums: Album[];
   recentAlbums: Album[];
@@ -6257,9 +6263,14 @@ function LibraryView({
               recentAlbums={recentAlbums}
               recentlyPlayedAlbums={recentlyPlayedAlbums}
               listeningHistory={listeningHistory}
+              currentTrack={currentTrack}
+              isPlaying={isPlaying}
+              radioStationName={radioStationName(radioStationState, appSettings.radioStationUrl)}
+              radioStatus={radioStatus}
               onPlaySong={onPlaySong}
               onPlayAlbum={onPlayAlbum}
               onSelectView={onSelectView}
+              onStartRadio={onStartRadio}
             />
           ) : null}
           {activeView === "nowPlaying" ? (
@@ -6390,20 +6401,32 @@ function OverviewHome({
   recentAlbums,
   recentlyPlayedAlbums,
   listeningHistory,
+  currentTrack,
+  isPlaying,
+  radioStationName,
+  radioStatus,
   onPlaySong,
   onPlayAlbum,
   onSelectView,
+  onStartRadio,
 }: {
   config: NavidromeConfig | null;
   albums: Album[];
   recentAlbums: Album[];
   recentlyPlayedAlbums: Album[];
   listeningHistory: ListeningHistoryEntry[];
+  currentTrack: Song | null;
+  isPlaying: boolean;
+  radioStationName: string;
+  radioStatus: RadioStatus;
   onPlaySong: (song: Song) => void;
   onPlayAlbum: (album: Album) => void;
   onSelectView: (view: View) => void;
+  onStartRadio: () => void;
 }) {
   const latestListen = listeningHistory[0]?.song;
+  const isContinuing = Boolean(latestListen && currentTrack?.id === latestListen.id && isPlaying);
+  const isRadioStarting = radioStatus === "checking";
   const [shuffleAlbums, setShuffleAlbums] = useState<Album[]>([]);
   const hour = new Date().getHours();
   const greeting = hour < 12 ? "Good morning" : hour < 18 ? "Good afternoon" : "Good evening";
@@ -6424,10 +6447,14 @@ function OverviewHome({
           <h3>{greeting}.</h3>
           <p>{latestListen ? `Pick up where you left off with ${latestListen.title}${latestListen.artist ? ` by ${latestListen.artist}` : ""}.` : config ? "Start a record, and Prism will keep the good stuff close at hand." : "Connect your library to make this space yours."}</p>
           {latestListen ? (
-            <button className="connect-button home-continue-button" type="button" onClick={() => onPlaySong(latestListen)}>
-              <Play size={16} fill="currentColor" />
-              Continue listening
-            </button>
+            isContinuing ? (
+              <span className="home-continue-status"><Pause size={16} fill="currentColor" /> Listening now</span>
+            ) : (
+              <button className="connect-button home-continue-button" type="button" onClick={() => onPlaySong(latestListen)}>
+                <Play size={16} fill="currentColor" />
+                Continue listening
+              </button>
+            )
           ) : null}
         </div>
         <div className="home-art-cluster" aria-label="Albums from your library">
@@ -6445,11 +6472,12 @@ function OverviewHome({
         <div className="home-radio-mark"><RadioTower size={22} /></div>
         <div>
           <p className="eyebrow">Live from Subwave</p>
-          <h4>Listen to Radio</h4>
+          <h4>Listen to {radioStationName}</h4>
           <p>A separate place for the live station, shows, and requests.</p>
         </div>
-        <button className="secondary-button home-radio-button" type="button" onClick={() => onSelectView("radio")}>
-          Open Radio <ChevronRight size={16} />
+        <button className="secondary-button home-radio-button" type="button" onClick={onStartRadio} disabled={isRadioStarting}>
+          {isRadioStarting ? <Loader2 className="spin" size={16} /> : <Play size={16} fill="currentColor" />}
+          {isRadioStarting ? "Tuning in" : `Listen to ${radioStationName}`}
         </button>
       </section>
       <HomeAlbumShelf title="Recently played" albums={visibleRecentAlbums} config={config} onPlayAlbum={onPlayAlbum} onOpenAlbum={() => onSelectView("recentlyPlayed")} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6581,28 +6581,6 @@ function HomeAlbumShelf({
   onOpenAlbum?: () => void;
   onRefresh?: () => void;
 }) {
-  const rowRef = useRef<HTMLDivElement>(null);
-  const [scrollMetrics, setScrollMetrics] = useState({ max: 0, value: 0 });
-
-  useEffect(() => {
-    const row = rowRef.current;
-    if (!row) return;
-
-    const updateScrollMetrics = () => {
-      const max = Math.max(0, row.scrollWidth - row.clientWidth);
-      setScrollMetrics({ max, value: Math.min(row.scrollLeft, max) });
-    };
-
-    updateScrollMetrics();
-    row.addEventListener("scroll", updateScrollMetrics, { passive: true });
-    const resizeObserver = new ResizeObserver(updateScrollMetrics);
-    resizeObserver.observe(row);
-    return () => {
-      row.removeEventListener("scroll", updateScrollMetrics);
-      resizeObserver.disconnect();
-    };
-  }, [albums]);
-
   if (!albums.length) return null;
 
   return (
@@ -6616,7 +6594,7 @@ function HomeAlbumShelf({
         {onOpenAlbum ? <button className="home-shelf-action" type="button" onClick={onOpenAlbum}>See all <ChevronRight size={15} /></button> : null}
       </div>
       <div className="home-album-carousel">
-        <div className="home-album-row" ref={rowRef} tabIndex={0} aria-label={`${title} albums`}>
+        <div className="home-album-row" tabIndex={0} aria-label={`${title} albums`}>
           {albums.map((album) => (
             <div className="home-album" key={album.id}>
               <PlayableCover
@@ -6632,18 +6610,6 @@ function HomeAlbumShelf({
             </div>
           ))}
         </div>
-        {scrollMetrics.max > 0 ? (
-          <input
-            className="home-album-scrollbar"
-            type="range"
-            min="0"
-            max={scrollMetrics.max}
-            value={scrollMetrics.value}
-            step="1"
-            aria-label={`Scroll ${title} albums`}
-            onChange={(event) => rowRef.current?.scrollTo({ left: Number(event.currentTarget.value) })}
-          />
-        ) : null}
       </div>
     </section>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,6 +125,7 @@ type AppSettings = {
   showSharedPlaylists: boolean;
   radioStationUrl: string;
   radioStationUrls: string[];
+  radioStationNames: Record<string, string>;
 };
 
 type Album = {
@@ -448,6 +449,7 @@ const defaultSettings: AppSettings = {
   showSharedPlaylists: true,
   radioStationUrl: "",
   radioStationUrls: [],
+  radioStationNames: {},
 };
 
 const ALPHABET = ["#", ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ"];
@@ -569,6 +571,18 @@ function normalizeRadioStationList(values: Array<string | undefined | null>) {
   return stations;
 }
 
+function normalizeRadioStationNames(values: Record<string, string> | undefined, stations: string[]) {
+  const names: Record<string, string> = {};
+
+  Object.entries(values ?? {}).forEach(([stationUrl, name]) => {
+    const origin = normalizeStationUrl(stationUrl);
+    const normalizedName = name.trim();
+    if (origin && stations.includes(origin) && normalizedName) names[origin] = normalizedName;
+  });
+
+  return names;
+}
+
 function loadStoredSettings(): AppSettings {
   try {
     const raw = localStorage.getItem(SETTINGS_KEY);
@@ -590,6 +604,7 @@ function loadStoredSettings(): AppSettings {
       showSharedPlaylists: parsed.showSharedPlaylists ?? defaultSettings.showSharedPlaylists,
       radioStationUrl: activeStation || radioStationUrls[0] || defaultSettings.radioStationUrl,
       radioStationUrls,
+      radioStationNames: normalizeRadioStationNames(parsed.radioStationNames, radioStationUrls),
     };
   } catch {
     return defaultSettings;
@@ -960,8 +975,9 @@ function formatRadioStreamLabel(bitrate: number | string | null | undefined, for
   return `${normalizedFormat} / ${bitrateText}`;
 }
 
-function radioStationName(state: RadioStationState | null, stationUrl: string) {
+function radioStationName(state: RadioStationState | null, stationUrl: string, savedName?: string) {
   return (
+    savedName ||
     state?.context?.stationName ||
     state?.context?.station?.name ||
     state?.station?.name ||
@@ -1953,6 +1969,7 @@ export function App() {
       lastVolume: clampNumber(nextSettings.lastVolume, 0, 1),
       radioStationUrl: activeStation,
       radioStationUrls: radioStationUrls.includes(activeStation) ? radioStationUrls : normalizeRadioStationList([activeStation, ...radioStationUrls]),
+      radioStationNames: normalizeRadioStationNames(nextSettings.radioStationNames, radioStationUrls),
     };
   }
 
@@ -1963,14 +1980,21 @@ export function App() {
     localStorage.setItem(SETTINGS_KEY, JSON.stringify(normalizedSettings));
   }
 
-  function saveRadioStation(origin: string) {
+  function saveRadioStation(origin: string, discoveredName?: string) {
     const normalized = normalizeStationUrl(origin);
     if (!normalized) return;
+
+    const stationUrls = normalizeRadioStationList([...appSettings.radioStationUrls, normalized]);
+    const existingName = appSettings.radioStationNames[normalized];
+    const name = discoveredName?.trim();
 
     updateAppSettings({
       ...appSettings,
       radioStationUrl: normalized,
-      radioStationUrls: normalizeRadioStationList([...appSettings.radioStationUrls, normalized]),
+      radioStationUrls: stationUrls,
+      // The first name returned by a station is remembered. A value edited in
+      // Settings is intentionally left alone as a user-friendly override.
+      radioStationNames: existingName || !name ? appSettings.radioStationNames : { ...appSettings.radioStationNames, [normalized]: name },
     });
     setRadioStationInput(normalized);
   }
@@ -2007,6 +2031,7 @@ export function App() {
       ...appSettings,
       radioStationUrl: activeStation,
       radioStationUrls: remainingStations,
+      radioStationNames: normalizeRadioStationNames(appSettings.radioStationNames, remainingStations),
     });
     setRadioStationInput(activeStation);
   }
@@ -2071,7 +2096,7 @@ export function App() {
       ]);
       applyRadioStationState(nextState);
       if (nextSession) applyRadioSession(nextSession);
-      saveRadioStation(origin);
+      saveRadioStation(origin, radioStationName(nextState, origin));
       setRadioStatus((currentStatus) => (currentStatus === "playing" ? "playing" : "ready"));
       setRadioMessage("Station connected.");
       return nextState;
@@ -3186,7 +3211,7 @@ export function App() {
         title: track.title ?? "Live radio",
         artist: track.artist ?? (radioPresence ? "Subwave" : "Unknown artist"),
         album: track.album ?? null,
-        station: radioPresence ? radioStationName(radioStationState, radioStationUrl) : null,
+        station: radioPresence ? radioStationName(radioStationState, radioStationUrl, appSettings.radioStationNames[radioStationUrl]) : null,
         playing: radioPresence ? true : isPlaying,
         startedAt: radioPresence || !isPlaying ? null : Date.now() - Math.round(position * 1000),
       },
@@ -3776,9 +3801,9 @@ export function App() {
 
   const radioDuration = radioNowPlaying?.duration ?? 0;
   const radioHasTimedTrack = Boolean(isRadioPlaying && radioNowPlaying && radioDuration > 0);
-  const footerRadioTitle = radioNowPlaying?.title ?? radioStationName(radioStationState, radioStationUrl);
+  const footerRadioTitle = radioNowPlaying?.title ?? radioStationName(radioStationState, radioStationUrl, appSettings.radioStationNames[radioStationUrl]);
   const footerRadioMeta = radioNowPlaying
-    ? radioNowPlaying.artist || radioStationName(radioStationState, radioStationUrl)
+    ? radioNowPlaying.artist || radioStationName(radioStationState, radioStationUrl, appSettings.radioStationNames[radioStationUrl])
     : "Live broadcast";
   const seekDuration = isRadioPlaying ? (radioHasTimedTrack ? radioDuration : Math.max(radioElapsed, 1)) : playerDuration || currentTrack?.duration || 0;
   const seekPosition = isRadioPlaying ? (radioHasTimedTrack ? Math.min(radioElapsed, radioDuration) : 0) : position;
@@ -5466,10 +5491,25 @@ function SettingsView({
           <div className="settings-station-list">
             {appSettings.radioStationUrls.map((stationUrl) => (
               <div className={`settings-station-row ${stationUrl === appSettings.radioStationUrl ? "active" : ""}`} key={stationUrl}>
-                <button className="settings-station-main" type="button" onClick={() => onSelectRadioStation(stationUrl)}>
-                  <RadioTower size={15} />
-                  <span>{stationUrl.replace(/^https?:\/\//, "")}</span>
-                </button>
+                <div className="settings-station-details">
+                  <button className="settings-station-main" type="button" onClick={() => onSelectRadioStation(stationUrl)}>
+                    <RadioTower size={15} />
+                    <span>{appSettings.radioStationNames[stationUrl] || stationUrl.replace(/^https?:\/\//, "")}</span>
+                  </button>
+                  <input
+                    className="settings-station-name"
+                    aria-label={`Display name for ${stationUrl}`}
+                    value={appSettings.radioStationNames[stationUrl] ?? ""}
+                    onChange={(event) => {
+                      const name = event.target.value.trim();
+                      const radioStationNames = { ...appSettings.radioStationNames };
+                      if (name) radioStationNames[stationUrl] = name;
+                      else delete radioStationNames[stationUrl];
+                      updateAppSettings({ ...appSettings, radioStationNames });
+                    }}
+                    placeholder="Display name (optional)"
+                  />
+                </div>
                 <button
                   className="icon-button"
                   type="button"
@@ -5497,7 +5537,7 @@ function SettingsView({
             Add
           </button>
         </form>
-        <p className="settings-note">Prism validates this against `/api/state` and plays the station stream from `/stream.mp3`.</p>
+        <p className="settings-note">Prism remembers the station name reported by `/api/state`; use Display name to override it. Streams play from `/stream.mp3`.</p>
       </section> : null}
 
       {activeTab === "privacy" ? <section className="settings-panel">
@@ -5842,7 +5882,8 @@ function RadioView({
   const [firstStationUrl, setFirstStationUrl] = useState("");
   const isPlaying = status === "playing";
   const isTuning = status === "checking";
-  const selectedStationLabel = stationUrl ? stationUrl.replace(/^https?:\/\//, "") : "No station selected";
+  const stationLabel = (url: string) => radioStationName(stationState, url, appSettings.radioStationNames[normalizeStationUrl(url)]);
+  const selectedStationLabel = stationUrl ? stationLabel(stationUrl) : "No station selected";
 
   if (!isPlaying) {
     return (
@@ -5864,7 +5905,7 @@ function RadioView({
                 <select value={stationUrl} onChange={(event) => onSelectStation(event.target.value)} disabled={isTuning}>
                   {savedStations.map((savedStationUrl) => (
                     <option value={savedStationUrl} key={savedStationUrl}>
-                      {savedStationUrl.replace(/^https?:\/\//, "")}
+                      {stationLabel(savedStationUrl)}
                     </option>
                   ))}
                 </select>
@@ -5904,7 +5945,7 @@ function RadioView({
 
   const nowPlaying = firstRadioTrack(stationState);
   const listenerCount = radioListenerCount(stationState);
-  const stationName = radioStationName(stationState, stationUrl);
+  const stationName = stationLabel(stationUrl);
   const showTiming = radioShowTiming(schedule, Date.now());
   const showName = stationState?.activeShow?.name ?? showTiming?.currentShow?.name;
   const personaId = showTiming?.currentShow?.personaId;
@@ -5960,7 +6001,7 @@ function RadioView({
               <select value={stationUrl} onChange={(event) => onSelectStation(event.target.value)}>
                 {savedStations.map((savedStationUrl) => (
                   <option value={savedStationUrl} key={savedStationUrl}>
-                    {savedStationUrl.replace(/^https?:\/\//, "")}
+                    {stationLabel(savedStationUrl)}
                   </option>
                 ))}
               </select>
@@ -6265,7 +6306,7 @@ function LibraryView({
               listeningHistory={listeningHistory}
               currentTrack={currentTrack}
               isPlaying={isPlaying}
-              radioStationName={radioStationName(radioStationState, appSettings.radioStationUrl)}
+              radioStationName={radioStationName(radioStationState, appSettings.radioStationUrl, appSettings.radioStationNames[normalizeStationUrl(appSettings.radioStationUrl)])}
               radioStatus={radioStatus}
               onPlaySong={onPlaySong}
               onPlayAlbum={onPlayAlbum}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -520,25 +520,6 @@ function getSettingsTabLabel(tab: SettingsTab) {
   return labels[tab];
 }
 
-function getGreetingPeriod() {
-  const hour = new Date().getHours();
-  if (hour < 5) return "night";
-  if (hour < 12) return "morning";
-  if (hour < 17) return "afternoon";
-  if (hour < 22) return "evening";
-  return "night";
-}
-
-function formatDisplayName(value?: string) {
-  if (!value) return "there";
-  return value
-    .trim()
-    .split(/[\s._-]+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
 function sortAlbumsChronologically(albums: Album[]) {
   return [...albums].sort((a, b) => {
     const yearA = a.year ?? Number.MAX_SAFE_INTEGER;
@@ -1961,33 +1942,6 @@ export function App() {
       () => queue.map((song, index) => ({ song, index })).slice(Math.max(currentIndex, 0)),
       [currentIndex, queue],
     );
-  const libraryItems = useMemo(
-    () => [
-      { label: "Artists", value: hasConfig ? `${libraryData.artists.length} loaded` : "Needs server" },
-      { label: "Albums", value: hasConfig ? `${libraryData.albums.length} loaded` : "Needs server" },
-      { label: "Playlists", value: hasConfig ? `${libraryData.playlists.length} loaded` : "Needs server" },
-      { label: "Recently Added", value: hasConfig ? `${libraryData.recentAlbums.length} albums` : "Needs server" },
-      { label: "Recently Played", value: hasConfig ? `${libraryData.recentlyPlayedAlbums.length} albums` : "Needs server" },
-      {
-        label: "Favorites",
-        value: hasConfig
-          ? `${libraryData.favorites.artists.length + libraryData.favorites.albums.length + libraryData.favorites.songs.length} saved`
-          : "Needs server",
-      },
-    ],
-    [
-      hasConfig,
-      libraryData.albums.length,
-      libraryData.artists.length,
-      libraryData.favorites.albums.length,
-      libraryData.favorites.artists.length,
-      libraryData.favorites.songs.length,
-      libraryData.playlists.length,
-      libraryData.recentAlbums.length,
-      libraryData.recentlyPlayedAlbums.length,
-    ],
-  );
-
   function normalizeAppSettings(nextSettings: AppSettings) {
     const radioStationUrls = normalizeRadioStationList([...nextSettings.radioStationUrls, nextSettings.radioStationUrl]);
     const activeStation = normalizeStationUrl(nextSettings.radioStationUrl) || radioStationUrls[0] || "";
@@ -4134,7 +4088,6 @@ export function App() {
               radioWaveformBars={radioWaveformBars}
               tuneInRadio={tuneInRadio}
               onAddFirstRadioStation={tuneInRadio}
-              libraryItems={libraryItems}
               albums={libraryData.albums}
               recentAlbums={libraryData.recentAlbums}
               recentlyPlayedAlbums={libraryData.recentlyPlayedAlbums}
@@ -4161,7 +4114,16 @@ export function App() {
               detailStatus={detailStatus}
               detailMessage={detailMessage}
               currentTrack={currentTrack}
+              currentTrackCoverUrl={currentTrackCoverUrl}
               isPlaying={isPlaying}
+              position={position}
+              duration={playerDuration || currentTrack?.duration || 0}
+              hasPrevious={currentIndex > 0}
+              hasNext={repeatMode === "all" || currentIndex < queue.length - 1}
+              onTogglePlayback={togglePlayback}
+              onPrevious={playPrevious}
+              onNext={() => playNext(false)}
+              onSeek={seekTo}
               favoriteIds={favoriteIds}
               favoriteBusyKey={favoriteBusyKey}
               onToggleFavorite={toggleFavorite}
@@ -6051,7 +6013,6 @@ function LibraryView({
   radioWaveformBars,
   tuneInRadio,
   onAddFirstRadioStation,
-  libraryItems,
   albums,
   recentAlbums,
   recentlyPlayedAlbums,
@@ -6077,7 +6038,16 @@ function LibraryView({
   detailStatus,
   detailMessage,
   currentTrack,
+  currentTrackCoverUrl,
   isPlaying,
+  position,
+  duration,
+  hasPrevious,
+  hasNext,
+  onTogglePlayback,
+  onPrevious,
+  onNext,
+  onSeek,
   favoriteIds,
   favoriteBusyKey,
   onToggleFavorite,
@@ -6112,7 +6082,6 @@ function LibraryView({
   radioWaveformBars: number[];
   tuneInRadio: () => Promise<void>;
   onAddFirstRadioStation: (stationUrl: string) => Promise<void>;
-  libraryItems: Array<{ label: string; value: string }>;
   albums: Album[];
   recentAlbums: Album[];
   recentlyPlayedAlbums: Album[];
@@ -6138,7 +6107,16 @@ function LibraryView({
   detailStatus: "idle" | "loading" | "error";
   detailMessage: string;
   currentTrack: Song | null;
+  currentTrackCoverUrl: string | null;
   isPlaying: boolean;
+  position: number;
+  duration: number;
+  hasPrevious: boolean;
+  hasNext: boolean;
+  onTogglePlayback: () => void;
+  onPrevious: () => void;
+  onNext: () => void;
+  onSeek: (position: number) => void;
   favoriteIds: FavoriteIds;
   favoriteBusyKey: string;
   onToggleFavorite: (kind: FavoriteKind, id: string, favorite: boolean) => void;
@@ -6268,13 +6246,22 @@ function LibraryView({
           {activeView === "overview" ? (
             <OverviewHome
               config={config}
-              libraryItems={libraryItems}
               recentAlbums={recentAlbums}
+              recentlyPlayedAlbums={recentlyPlayedAlbums}
               currentTrack={currentTrack}
+              currentTrackCoverUrl={currentTrackCoverUrl}
               isPlaying={isPlaying}
+              position={position}
+              duration={duration}
               favoriteIds={favoriteIds}
               favoriteBusyKey={favoriteBusyKey}
               onToggleFavorite={onToggleFavorite}
+              hasPrevious={hasPrevious}
+              hasNext={hasNext}
+              onTogglePlayback={onTogglePlayback}
+              onPrevious={onPrevious}
+              onNext={onNext}
+              onSeek={onSeek}
               onSelectLibraryView={onSelectLibraryView}
               onOpenAlbum={onOpenAlbum}
               onPlayAlbum={onPlayAlbum}
@@ -6388,111 +6375,101 @@ function LibraryView({
 
 function OverviewHome({
   config,
-  libraryItems,
   recentAlbums,
+  recentlyPlayedAlbums,
   currentTrack,
+  currentTrackCoverUrl,
   isPlaying,
+  position,
+  duration,
   favoriteIds,
   favoriteBusyKey,
   onToggleFavorite,
+  hasPrevious,
+  hasNext,
+  onTogglePlayback,
+  onPrevious,
+  onNext,
+  onSeek,
   onSelectLibraryView,
   onOpenAlbum,
   onPlayAlbum,
 }: {
   config: NavidromeConfig | null;
-  libraryItems: Array<{ label: string; value: string }>;
   recentAlbums: Album[];
+  recentlyPlayedAlbums: Album[];
   currentTrack: Song | null;
+  currentTrackCoverUrl: string | null;
   isPlaying: boolean;
+  position: number;
+  duration: number;
   favoriteIds: FavoriteIds;
   favoriteBusyKey: string;
   onToggleFavorite: (kind: FavoriteKind, id: string, favorite: boolean) => void;
+  hasPrevious: boolean;
+  hasNext: boolean;
+  onTogglePlayback: () => void;
+  onPrevious: () => void;
+  onNext: () => void;
+  onSeek: (position: number) => void;
   onSelectLibraryView: (view: View) => void;
   onOpenAlbum: (album: Album) => void;
   onPlayAlbum: (album: Album) => void;
 }) {
-  const shortcutItems = libraryItems;
-  const visualAlbums = recentAlbums.slice(0, 5);
-  const featuredAlbum = visualAlbums[0] ?? null;
-  const featuredCoverUrl = config && featuredAlbum ? buildCoverArtUrl(config, featuredAlbum.coverArt, "520") : null;
-  const greeting = `Good ${getGreetingPeriod()}, ${formatDisplayName(config?.username)}`;
-  const librarySummary = libraryItems
-    .slice(0, 3)
-    .map((item) => `${item.value.replace(" loaded", "")} ${item.label.toLowerCase()}`)
-    .join(" · ");
-  const currentTrackSummary = currentTrack ? `${currentTrack.title} - ${currentTrack.artist ?? "Unknown artist"}` : "";
-  const shortcutMeta: Record<string, ReactNode> = {
-    Artists: <UserRound size={18} />,
-    Albums: <Disc3 size={18} />,
-    Playlists: <ListMusic size={18} />,
-    "Recently Added": <Plus size={18} />,
-    "Recently Played": <History size={18} />,
-    Favorites: <Star size={18} />,
-  };
+  const visualAlbums = (recentlyPlayedAlbums.length ? recentlyPlayedAlbums : recentAlbums).slice(0, 8);
+  const hasTrack = Boolean(currentTrack);
+  const progress = Math.min(position, Math.max(duration, 1));
 
   return (
     <div className="home-view">
-      <section className="home-hero">
-        <div className="home-hero-copy">
-          <p className="eyebrow">Home</p>
-          <h3>{greeting}</h3>
-          <p className="home-library-state">{config ? librarySummary : "Connect Navidrome to load your library."}</p>
-          {isPlaying && currentTrackSummary ? <p className="home-now-playing">Now playing: {currentTrackSummary}</p> : null}
-        </div>
-        <div className="home-cover-stage">
-          {visualAlbums.map((album, index) => {
-            const coverUrl = config ? buildCoverArtUrl(config, album.coverArt, index === 0 ? "520" : "260") : null;
-
-            return (
-              <button
-                className={`home-cover-peek peek-${index + 1}`}
-                type="button"
-                key={album.id}
-                onClick={() => onOpenAlbum(album)}
-                aria-label={`Open ${album.name}`}
-              >
-                <CoverArt src={coverUrl} label={album.name} className="home-cover-art" />
-              </button>
-            );
-          })}
-          {!visualAlbums.length ? <CoverArt src={featuredCoverUrl} label="Prism library" className="home-cover-art home-cover-empty" /> : null}
-        </div>
-      </section>
-
-      <section>
+      <section className="home-listening-ribbon" aria-labelledby="recent-listening-title">
         <div className="section-label">
-          <h4>Library</h4>
+          <div>
+            <p className="eyebrow">Your listening</p>
+            <h4 id="recent-listening-title">Recently played</h4>
+          </div>
+          <button className="detail-back" type="button" onClick={() => onSelectLibraryView("recentlyPlayed")}>View history</button>
         </div>
-        <div className="home-shortcuts">
-          {shortcutItems.map((item) => (
-            <button
-              className="home-shortcut"
-              type="button"
-              key={item.label}
-              onClick={() => {
-                if (item.label === "Albums") onSelectLibraryView("albums");
-                if (item.label === "Artists") onSelectLibraryView("artists");
-                if (item.label === "Playlists") onSelectLibraryView("playlists");
-                if (item.label === "Recently Added") onSelectLibraryView("recentlyAdded");
-                if (item.label === "Recently Played") onSelectLibraryView("recentlyPlayed");
-                if (item.label === "Favorites") onSelectLibraryView("favorites");
-              }}
-            >
-              <span className="home-shortcut-icon">{shortcutMeta[item.label]}</span>
-              <span className="home-shortcut-copy">
-                <strong>{item.label}</strong>
-                <small>{item.value}</small>
-              </span>
-              <ChevronRight size={16} />
+        <div className="home-art-ribbon">
+          {visualAlbums.map((album) => (
+            <button className="home-ribbon-album" type="button" key={album.id} onClick={() => onOpenAlbum(album)} aria-label={`Open ${album.name}`}>
+              <CoverArt src={config ? buildCoverArtUrl(config, album.coverArt, "240") : null} label={album.name} className="home-ribbon-cover" />
             </button>
           ))}
+          {!visualAlbums.length ? <p className="home-ribbon-empty">Play something to make this home feel like yours.</p> : null}
+        </div>
+      </section>
+
+      <section className={`home-now-playing-hero ${hasTrack ? "has-track" : ""}`}>
+        <div className="home-now-playing-art">
+          <CoverArt src={currentTrackCoverUrl} label={currentTrack?.title ?? "Prism Player"} className="home-now-playing-cover" />
+        </div>
+        <div className="home-now-playing-copy">
+          <p className="eyebrow">{isPlaying ? "Now playing" : hasTrack ? "Paused" : "Ready when you are"}</p>
+          <h3>{currentTrack?.title ?? "Your next listen starts here"}</h3>
+          <p>{currentTrack ? `${currentTrack.artist ?? "Unknown artist"}${currentTrack.album ? ` · ${currentTrack.album}` : ""}` : config ? "Pick an album, artist, or song from your library." : "Connect your Navidrome server to bring your music home."}</p>
+          <div className="home-playback-controls">
+            <button type="button" aria-label="Previous" onClick={onPrevious} disabled={!hasPrevious}><SkipBack size={18} /></button>
+            <button className="home-primary-play" type="button" aria-label={isPlaying ? "Pause" : "Play"} onClick={onTogglePlayback} disabled={!hasTrack}>
+              {isPlaying ? <Pause size={21} fill="currentColor" /> : <Play size={21} fill="currentColor" />}
+            </button>
+            <button type="button" aria-label="Next" onClick={onNext} disabled={!hasNext}><SkipForward size={18} /></button>
+          </div>
+          <div className="home-seek-row">
+            <span>{formatDuration(position)}</span>
+            <input type="range" min="0" max={Math.max(duration, 1)} step="1" value={progress} onChange={(event) => onSeek(Number(event.target.value))} disabled={!hasTrack || !duration} aria-label="Seek" />
+            <span>{formatDuration(duration)}</span>
+          </div>
         </div>
       </section>
 
       <section>
         <div className="section-label">
-          <h4>Recently added</h4>
-          <button className="detail-back" type="button" onClick={() => onSelectLibraryView("albums")}>
+          <div>
+            <p className="eyebrow">Fresh in your library</p>
+            <h4>Recently added</h4>
+          </div>
+          <button className="detail-back" type="button" onClick={() => onSelectLibraryView("recentlyAdded")}>
             View albums
           </button>
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6507,14 +6507,14 @@ function OverviewHome({
   const hour = new Date().getHours();
   const greeting = hour < 12 ? "Good morning" : hour < 18 ? "Good afternoon" : "Good evening";
   const listenerName = config?.name.trim();
-  const visibleRecentAlbums = recentlyPlayedAlbums.slice(0, 3);
-  const visibleNewAlbums = recentAlbums.slice(0, 3);
+  const visibleRecentAlbums = recentlyPlayedAlbums.slice(0, 5);
+  const visibleNewAlbums = recentAlbums.slice(0, 5);
 
   useEffect(() => {
-    setShuffleAlbums(shuffled(albums).slice(0, 3));
+    setShuffleAlbums(shuffled(albums).slice(0, 5));
   }, [albums]);
 
-  const refreshShuffleAlbums = () => setShuffleAlbums(shuffled(albums).slice(0, 3));
+  const refreshShuffleAlbums = () => setShuffleAlbums(shuffled(albums).slice(0, 5));
 
   return (
     <div className="home-dashboard">
@@ -6535,7 +6535,7 @@ function OverviewHome({
           ) : null}
         </div>
         <div className="home-art-cluster" aria-label="Albums from your library">
-          {visibleRecentAlbums.length ? visibleRecentAlbums.map((album, index) => (
+          {visibleRecentAlbums.length ? visibleRecentAlbums.slice(0, 3).map((album, index) => (
             <CoverArt
               key={album.id}
               src={config ? buildCoverArtUrl(config, album.coverArt, "320") : null}
@@ -6593,7 +6593,7 @@ function HomeAlbumShelf({
         {onRefresh ? <button className="home-shelf-action" type="button" onClick={onRefresh}><RefreshCw size={15} /> Refresh</button> : null}
         {onOpenAlbum ? <button className="home-shelf-action" type="button" onClick={onOpenAlbum}>See all <ChevronRight size={15} /></button> : null}
       </div>
-      <div className="home-album-row">
+      <div className="home-album-row" tabIndex={0} aria-label={`${title} albums`}>
         {albums.map((album) => (
           <div className="home-album" key={album.id}>
             <PlayableCover

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import {
   Disc3,
   Download,
   ExternalLink,
+  Maximize2,
   History,
   Heart,
   Home,
@@ -52,7 +53,7 @@ import {
 import packageJson from "../package.json";
 
 type LibraryViewMode = "overview" | "albums" | "artists" | "songs" | "playlists" | "recentlyAdded" | "recentlyPlayed" | "favorites";
-type View = LibraryViewMode | "radio" | "search" | "settings";
+type View = LibraryViewMode | "nowPlaying" | "radio" | "search" | "settings";
 type SettingsTab = "connection" | "library" | "appearance" | "radio" | "privacy" | "about" | "advanced";
 type ConnectionStatus = "idle" | "checking" | "connected" | "error";
 type LibraryStatus = "idle" | "loading" | "ready" | "error";
@@ -498,6 +499,7 @@ function getViewLabel(view: View) {
     recentlyAdded: "Recently Added",
     recentlyPlayed: "Recently Played",
     favorites: "Favorites",
+    nowPlaying: "Now Playing",
     radio: "Radio",
     search: "Search",
     settings: "Settings",
@@ -4115,12 +4117,6 @@ export function App() {
               currentTrack={currentTrack}
               currentTrackCoverUrl={currentTrackCoverUrl}
               isPlaying={isPlaying}
-              activePlaybackSource={activePlaybackSource}
-              radioNowPlaying={radioNowPlaying}
-              radioCoverUrl={radioCoverUrl}
-              radioStationName={radioStationName(radioStationState, radioStationUrl)}
-              hasRadioStation={Boolean(radioStationUrl)}
-              isRadioPlaying={isRadioPlaying}
               position={position}
               duration={playerDuration || currentTrack?.duration || 0}
               hasPrevious={currentIndex > 0}
@@ -4191,7 +4187,10 @@ export function App() {
               <CoverArt src={null} label="Radio" className="player-cover" fallbackIcon={<RadioTower size={20} />} />
             )
           ) : footerTrack ? (
-            <CoverArt src={footerTrackCoverUrl} label={footerTrack.title} className="player-cover" fallbackIcon={<Music2 size={20} />} />
+            <button className="player-now-playing-trigger" type="button" onClick={() => selectView("nowPlaying")} aria-label={`Open Now Playing for ${footerTrack.title}`}>
+              <CoverArt src={footerTrackCoverUrl} label={footerTrack.title} className="player-cover" fallbackIcon={<Music2 size={20} />} />
+              <Maximize2 size={14} aria-hidden="true" />
+            </button>
           ) : null}
           <div className="now-playing-copy">
             {isRadioPresentation ? (
@@ -6044,12 +6043,6 @@ function LibraryView({
   currentTrack,
   currentTrackCoverUrl,
   isPlaying,
-  activePlaybackSource,
-  radioNowPlaying,
-  radioCoverUrl,
-  radioStationName,
-  hasRadioStation,
-  isRadioPlaying,
   position,
   duration,
   hasPrevious,
@@ -6118,12 +6111,6 @@ function LibraryView({
   currentTrack: Song | null;
   currentTrackCoverUrl: string | null;
   isPlaying: boolean;
-  activePlaybackSource: "local" | "radio";
-  radioNowPlaying: RadioTrack | null;
-  radioCoverUrl: string | null;
-  radioStationName: string;
-  hasRadioStation: boolean;
-  isRadioPlaying: boolean;
   position: number;
   duration: number;
   hasPrevious: boolean;
@@ -6183,7 +6170,7 @@ function LibraryView({
   const showLibraryError = libraryStatus === "error" && activeView !== "search";
 
   return (
-    <section className={`browser-panel ${activeView === "overview" ? "home-panel" : ""}`}>
+    <section className={`browser-panel ${activeView === "overview" || activeView === "nowPlaying" ? "home-panel" : ""}`}>
       {detailStatus !== "idle" || detailSelection ? (
         <DetailPanel
           config={config}
@@ -6212,7 +6199,7 @@ function LibraryView({
         />
       ) : (
         <>
-          {activeView !== "overview" ? (
+          {activeView !== "overview" && activeView !== "nowPlaying" ? (
             <div className="panel-heading browser-heading">
               <h3>{panelTitle}</h3>
               <div className="heading-actions">
@@ -6263,15 +6250,17 @@ function LibraryView({
           {activeView === "overview" ? (
             <OverviewHome
               config={config}
+              recentlyPlayedAlbums={recentlyPlayedAlbums}
+              listeningHistory={listeningHistory}
+              onPlaySong={onPlaySong}
+            />
+          ) : null}
+          {activeView === "nowPlaying" ? (
+            <NowPlayingView
+              config={config}
               currentTrack={currentTrack}
               currentTrackCoverUrl={currentTrackCoverUrl}
               isPlaying={isPlaying}
-              activePlaybackSource={activePlaybackSource}
-              radioNowPlaying={radioNowPlaying}
-              radioCoverUrl={radioCoverUrl}
-              radioStationName={radioStationName}
-              hasRadioStation={hasRadioStation}
-              isRadioPlaying={isRadioPlaying}
               position={position}
               duration={duration}
               hasPrevious={hasPrevious}
@@ -6390,15 +6379,52 @@ function LibraryView({
 
 function OverviewHome({
   config,
+  recentlyPlayedAlbums,
+  listeningHistory,
+  onPlaySong,
+}: {
+  config: NavidromeConfig | null;
+  recentlyPlayedAlbums: Album[];
+  listeningHistory: ListeningHistoryEntry[];
+  onPlaySong: (song: Song) => void;
+}) {
+  const artAlbums = recentlyPlayedAlbums.slice(0, 5);
+  const latestListen = listeningHistory[0]?.song;
+
+  return (
+    <div className="home-dashboard">
+      <section className="home-dashboard-intro">
+        <div>
+          <p className="eyebrow">Your listening</p>
+          <h3>Music, close at hand.</h3>
+          <p>{latestListen ? `Last played: ${latestListen.title}${latestListen.artist ? ` by ${latestListen.artist}` : ""}` : config ? "Start a record, and Prism will keep your recent listening here." : "Connect your library to make this space yours."}</p>
+          {latestListen ? (
+            <button className="connect-button home-continue-button" type="button" onClick={() => onPlaySong(latestListen)}>
+              <Play size={16} fill="currentColor" />
+              Continue listening
+            </button>
+          ) : null}
+        </div>
+        <div className="home-art-cluster" aria-label="Recently played albums">
+          {artAlbums.length ? artAlbums.map((album, index) => (
+            <CoverArt
+              key={album.id}
+              src={config ? buildCoverArtUrl(config, album.coverArt, "320") : null}
+              label={album.name}
+              className={`home-cluster-art home-cluster-art-${index + 1}`}
+            />
+          )) : <div className="home-cluster-empty"><Music2 size={34} /></div>}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function NowPlayingView({
+  config,
   currentTrack,
   currentTrackCoverUrl,
   isPlaying,
-  activePlaybackSource,
-  radioNowPlaying,
-  radioCoverUrl,
-  radioStationName,
-  hasRadioStation,
-  isRadioPlaying,
   position,
   duration,
   hasPrevious,
@@ -6412,12 +6438,6 @@ function OverviewHome({
   currentTrack: Song | null;
   currentTrackCoverUrl: string | null;
   isPlaying: boolean;
-  activePlaybackSource: "local" | "radio";
-  radioNowPlaying: RadioTrack | null;
-  radioCoverUrl: string | null;
-  radioStationName: string;
-  hasRadioStation: boolean;
-  isRadioPlaying: boolean;
   position: number;
   duration: number;
   hasPrevious: boolean;
@@ -6427,50 +6447,40 @@ function OverviewHome({
   onNext: () => void;
   onSeek: (position: number) => void;
 }) {
-  const isRadio = activePlaybackSource === "radio" && hasRadioStation;
   const hasTrack = Boolean(currentTrack);
-  const hasPlayback = isRadio || hasTrack;
-  const title = isRadio ? radioNowPlaying?.title ?? "Tune into Subwave" : currentTrack?.title ?? "Your next listen starts here";
-  const byline = isRadio
-    ? radioNowPlaying
-      ? `${radioNowPlaying.artist ?? radioStationName}${radioNowPlaying.album ? ` · ${radioNowPlaying.album}` : ""}`
-      : radioStationName
-    : currentTrack
-      ? `${currentTrack.artist ?? "Unknown artist"}${currentTrack.album ? ` · ${currentTrack.album}` : ""}`
-      : config
-        ? "Pick an album, artist, or song from your library."
-        : "Connect your Navidrome server to bring your music home.";
-  const coverUrl = isRadio ? radioCoverUrl : currentTrackCoverUrl;
-  const playing = isRadio ? isRadioPlaying : isPlaying;
+  const title = currentTrack?.title ?? "Your next listen starts here";
+  const byline = currentTrack
+    ? `${currentTrack.artist ?? "Unknown artist"}${currentTrack.album ? ` · ${currentTrack.album}` : ""}`
+    : config
+      ? "Pick an album, artist, or song from your library."
+      : "Connect your Navidrome server to bring your music home.";
   const progress = Math.min(position, Math.max(duration, 1));
 
   return (
     <div className="home-view">
-      <section className={`home-now-playing-hero ${hasPlayback ? "has-track" : ""} ${isRadio ? "is-radio" : ""}`}>
-        {coverUrl ? (
-          <div className="home-cover-wash" style={{ backgroundImage: `url(${coverUrl})` }} aria-hidden="true" />
+      <section className={`home-now-playing-hero ${hasTrack ? "has-track" : ""}`}>
+        {currentTrackCoverUrl ? (
+          <div className="home-cover-wash" style={{ backgroundImage: `url(${currentTrackCoverUrl})` }} aria-hidden="true" />
         ) : null}
         <div className="home-now-playing-art">
-          <CoverArt src={coverUrl} label={title} className="home-now-playing-cover" fallbackIcon={isRadio ? <RadioTower size={42} /> : <Music2 size={42} />} />
+          <CoverArt src={currentTrackCoverUrl} label={title} className="home-now-playing-cover" fallbackIcon={<Music2 size={42} />} />
         </div>
         <div className="home-now-playing-copy">
-          <p className="eyebrow">{isRadio ? (playing ? "On air · Subwave" : "Radio · Subwave") : playing ? "Now playing" : hasTrack ? "Paused" : "Ready when you are"}</p>
+          <p className="eyebrow">{isPlaying ? "Now playing" : hasTrack ? "Paused" : "Ready when you are"}</p>
           <h3>{title}</h3>
           <p>{byline}</p>
           <div className="home-playback-controls">
-            {!isRadio ? <button type="button" aria-label="Previous" onClick={onPrevious} disabled={!hasPrevious}><SkipBack size={18} /></button> : null}
-            <button className="home-primary-play" type="button" aria-label={playing ? "Pause" : isRadio ? "Tune in" : "Play"} onClick={onTogglePlayback} disabled={!hasPlayback}>
-              {playing ? <Pause size={21} fill="currentColor" /> : <Play size={21} fill="currentColor" />}
+            <button type="button" aria-label="Previous" onClick={onPrevious} disabled={!hasPrevious}><SkipBack size={18} /></button>
+            <button className="home-primary-play" type="button" aria-label={isPlaying ? "Pause" : "Play"} onClick={onTogglePlayback} disabled={!hasTrack}>
+              {isPlaying ? <Pause size={21} fill="currentColor" /> : <Play size={21} fill="currentColor" />}
             </button>
-            {!isRadio ? <button type="button" aria-label="Next" onClick={onNext} disabled={!hasNext}><SkipForward size={18} /></button> : null}
+            <button type="button" aria-label="Next" onClick={onNext} disabled={!hasNext}><SkipForward size={18} /></button>
           </div>
-          {isRadio ? <p className="home-radio-status">{playing ? "Live stream" : "Ready to tune in"}</p> : (
-            <div className="home-seek-row">
-              <span>{formatDuration(position)}</span>
-              <input type="range" min="0" max={Math.max(duration, 1)} step="1" value={progress} onChange={(event) => onSeek(Number(event.target.value))} disabled={!hasTrack || !duration} aria-label="Seek" />
-              <span>{formatDuration(duration)}</span>
-            </div>
-          )}
+          <div className="home-seek-row">
+            <span>{formatDuration(position)}</span>
+            <input type="range" min="0" max={Math.max(duration, 1)} step="1" value={progress} onChange={(event) => onSeek(Number(event.target.value))} disabled={!hasTrack || !duration} aria-label="Seek" />
+            <span>{formatDuration(duration)}</span>
+          </div>
         </div>
       </section>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4115,6 +4115,12 @@ export function App() {
               currentTrack={currentTrack}
               currentTrackCoverUrl={currentTrackCoverUrl}
               isPlaying={isPlaying}
+              activePlaybackSource={activePlaybackSource}
+              radioNowPlaying={radioNowPlaying}
+              radioCoverUrl={radioCoverUrl}
+              radioStationName={radioStationName(radioStationState, radioStationUrl)}
+              hasRadioStation={Boolean(radioStationUrl)}
+              isRadioPlaying={isRadioPlaying}
               position={position}
               duration={playerDuration || currentTrack?.duration || 0}
               hasPrevious={currentIndex > 0}
@@ -6038,6 +6044,12 @@ function LibraryView({
   currentTrack,
   currentTrackCoverUrl,
   isPlaying,
+  activePlaybackSource,
+  radioNowPlaying,
+  radioCoverUrl,
+  radioStationName,
+  hasRadioStation,
+  isRadioPlaying,
   position,
   duration,
   hasPrevious,
@@ -6106,6 +6118,12 @@ function LibraryView({
   currentTrack: Song | null;
   currentTrackCoverUrl: string | null;
   isPlaying: boolean;
+  activePlaybackSource: "local" | "radio";
+  radioNowPlaying: RadioTrack | null;
+  radioCoverUrl: string | null;
+  radioStationName: string;
+  hasRadioStation: boolean;
+  isRadioPlaying: boolean;
   position: number;
   duration: number;
   hasPrevious: boolean;
@@ -6248,6 +6266,12 @@ function LibraryView({
               currentTrack={currentTrack}
               currentTrackCoverUrl={currentTrackCoverUrl}
               isPlaying={isPlaying}
+              activePlaybackSource={activePlaybackSource}
+              radioNowPlaying={radioNowPlaying}
+              radioCoverUrl={radioCoverUrl}
+              radioStationName={radioStationName}
+              hasRadioStation={hasRadioStation}
+              isRadioPlaying={isRadioPlaying}
               position={position}
               duration={duration}
               hasPrevious={hasPrevious}
@@ -6369,6 +6393,12 @@ function OverviewHome({
   currentTrack,
   currentTrackCoverUrl,
   isPlaying,
+  activePlaybackSource,
+  radioNowPlaying,
+  radioCoverUrl,
+  radioStationName,
+  hasRadioStation,
+  isRadioPlaying,
   position,
   duration,
   hasPrevious,
@@ -6382,6 +6412,12 @@ function OverviewHome({
   currentTrack: Song | null;
   currentTrackCoverUrl: string | null;
   isPlaying: boolean;
+  activePlaybackSource: "local" | "radio";
+  radioNowPlaying: RadioTrack | null;
+  radioCoverUrl: string | null;
+  radioStationName: string;
+  hasRadioStation: boolean;
+  isRadioPlaying: boolean;
   position: number;
   duration: number;
   hasPrevious: boolean;
@@ -6391,34 +6427,50 @@ function OverviewHome({
   onNext: () => void;
   onSeek: (position: number) => void;
 }) {
+  const isRadio = activePlaybackSource === "radio" && hasRadioStation;
   const hasTrack = Boolean(currentTrack);
+  const hasPlayback = isRadio || hasTrack;
+  const title = isRadio ? radioNowPlaying?.title ?? "Tune into Subwave" : currentTrack?.title ?? "Your next listen starts here";
+  const byline = isRadio
+    ? radioNowPlaying
+      ? `${radioNowPlaying.artist ?? radioStationName}${radioNowPlaying.album ? ` · ${radioNowPlaying.album}` : ""}`
+      : radioStationName
+    : currentTrack
+      ? `${currentTrack.artist ?? "Unknown artist"}${currentTrack.album ? ` · ${currentTrack.album}` : ""}`
+      : config
+        ? "Pick an album, artist, or song from your library."
+        : "Connect your Navidrome server to bring your music home.";
+  const coverUrl = isRadio ? radioCoverUrl : currentTrackCoverUrl;
+  const playing = isRadio ? isRadioPlaying : isPlaying;
   const progress = Math.min(position, Math.max(duration, 1));
 
   return (
     <div className="home-view">
-      <section className={`home-now-playing-hero ${hasTrack ? "has-track" : ""}`}>
-        {currentTrackCoverUrl ? (
-          <div className="home-cover-wash" style={{ backgroundImage: `url(${currentTrackCoverUrl})` }} aria-hidden="true" />
+      <section className={`home-now-playing-hero ${hasPlayback ? "has-track" : ""} ${isRadio ? "is-radio" : ""}`}>
+        {coverUrl ? (
+          <div className="home-cover-wash" style={{ backgroundImage: `url(${coverUrl})` }} aria-hidden="true" />
         ) : null}
         <div className="home-now-playing-art">
-          <CoverArt src={currentTrackCoverUrl} label={currentTrack?.title ?? "Prism Player"} className="home-now-playing-cover" />
+          <CoverArt src={coverUrl} label={title} className="home-now-playing-cover" fallbackIcon={isRadio ? <RadioTower size={42} /> : <Music2 size={42} />} />
         </div>
         <div className="home-now-playing-copy">
-          <p className="eyebrow">{isPlaying ? "Now playing" : hasTrack ? "Paused" : "Ready when you are"}</p>
-          <h3>{currentTrack?.title ?? "Your next listen starts here"}</h3>
-          <p>{currentTrack ? `${currentTrack.artist ?? "Unknown artist"}${currentTrack.album ? ` · ${currentTrack.album}` : ""}` : config ? "Pick an album, artist, or song from your library." : "Connect your Navidrome server to bring your music home."}</p>
+          <p className="eyebrow">{isRadio ? (playing ? "On air · Subwave" : "Radio · Subwave") : playing ? "Now playing" : hasTrack ? "Paused" : "Ready when you are"}</p>
+          <h3>{title}</h3>
+          <p>{byline}</p>
           <div className="home-playback-controls">
-            <button type="button" aria-label="Previous" onClick={onPrevious} disabled={!hasPrevious}><SkipBack size={18} /></button>
-            <button className="home-primary-play" type="button" aria-label={isPlaying ? "Pause" : "Play"} onClick={onTogglePlayback} disabled={!hasTrack}>
-              {isPlaying ? <Pause size={21} fill="currentColor" /> : <Play size={21} fill="currentColor" />}
+            {!isRadio ? <button type="button" aria-label="Previous" onClick={onPrevious} disabled={!hasPrevious}><SkipBack size={18} /></button> : null}
+            <button className="home-primary-play" type="button" aria-label={playing ? "Pause" : isRadio ? "Tune in" : "Play"} onClick={onTogglePlayback} disabled={!hasPlayback}>
+              {playing ? <Pause size={21} fill="currentColor" /> : <Play size={21} fill="currentColor" />}
             </button>
-            <button type="button" aria-label="Next" onClick={onNext} disabled={!hasNext}><SkipForward size={18} /></button>
+            {!isRadio ? <button type="button" aria-label="Next" onClick={onNext} disabled={!hasNext}><SkipForward size={18} /></button> : null}
           </div>
-          <div className="home-seek-row">
-            <span>{formatDuration(position)}</span>
-            <input type="range" min="0" max={Math.max(duration, 1)} step="1" value={progress} onChange={(event) => onSeek(Number(event.target.value))} disabled={!hasTrack || !duration} aria-label="Seek" />
-            <span>{formatDuration(duration)}</span>
-          </div>
+          {isRadio ? <p className="home-radio-status">{playing ? "Live stream" : "Ready to tune in"}</p> : (
+            <div className="home-seek-row">
+              <span>{formatDuration(position)}</span>
+              <input type="range" min="0" max={Math.max(duration, 1)} step="1" value={progress} onChange={(event) => onSeek(Number(event.target.value))} disabled={!hasTrack || !duration} aria-label="Seek" />
+              <span>{formatDuration(duration)}</span>
+            </div>
+          )}
         </div>
       </section>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6207,6 +6207,19 @@ function LibraryView({
   onQueueSong: (song: Song) => void;
   onRetryLibrary: () => void;
 }) {
+  const [isHomeScrollbarVisible, setIsHomeScrollbarVisible] = useState(false);
+  const homeScrollbarTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => () => {
+    if (homeScrollbarTimeoutRef.current !== null) window.clearTimeout(homeScrollbarTimeoutRef.current);
+  }, []);
+
+  function revealHomeScrollbar() {
+    setIsHomeScrollbarVisible(true);
+    if (homeScrollbarTimeoutRef.current !== null) window.clearTimeout(homeScrollbarTimeoutRef.current);
+    homeScrollbarTimeoutRef.current = window.setTimeout(() => setIsHomeScrollbarVisible(false), 700);
+  }
+
   if (activeView === "radio") {
     return (
       <RadioView
@@ -6239,7 +6252,10 @@ function LibraryView({
   const showLibraryError = libraryStatus === "error" && activeView !== "search";
 
   return (
-    <section className={`browser-panel ${activeView === "overview" || activeView === "nowPlaying" ? "home-panel" : ""}`}>
+    <section
+      className={`browser-panel ${activeView === "overview" || activeView === "nowPlaying" ? `home-panel ${isHomeScrollbarVisible ? "is-scrolling" : ""}` : ""}`}
+      onScroll={activeView === "overview" || activeView === "nowPlaying" ? revealHomeScrollbar : undefined}
+    >
       {detailStatus !== "idle" || detailSelection ? (
         <DetailPanel
           config={config}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1356,10 +1356,6 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   pointer-events: none;
 }
 
-.home-now-playing-hero.is-radio {
-  grid-template-columns: minmax(180px, 0.6fr) minmax(0, 1fr);
-}
-
 .home-now-playing-art,
 .home-now-playing-copy {
   position: relative;
@@ -1372,16 +1368,6 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   overflow: hidden;
   border-radius: 10px;
   box-shadow: 0 28px 54px rgba(0, 0, 0, 0.38);
-}
-
-.home-now-playing-hero.is-radio .home-now-playing-art {
-  border-radius: 50%;
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.12), 0 32px 80px rgba(0, 0, 0, 0.48);
-}
-
-.home-now-playing-hero.is-radio .home-now-playing-art img,
-.home-now-playing-hero.is-radio .home-now-playing-art .cover-fallback {
-  border-radius: inherit;
 }
 
 .home-now-playing-art img,
@@ -1463,24 +1449,93 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   width: 100%;
 }
 
-.home-radio-status {
-  margin: 8px 0 0;
-  color: rgba(244, 241, 236, 0.58);
-  font-size: 12px;
+.home-dashboard {
+  display: grid;
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: clamp(26px, 5vw, 72px);
 }
 
-.home-radio-status::before {
-  display: inline-block;
-  width: 7px;
-  height: 7px;
-  margin-right: 7px;
-  border-radius: 50%;
-  background: #ef7868;
-  box-shadow: 0 0 14px rgba(239, 120, 104, 0.7);
-  content: "";
+.home-dashboard-intro {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(270px, 0.72fr);
+  align-items: center;
+  gap: clamp(32px, 7vw, 112px);
+  max-width: 1040px;
+  margin: auto;
+}
+
+.home-dashboard-intro h3 {
+  max-width: 620px;
+  margin: 6px 0 12px;
+  font-size: clamp(38px, 5vw, 64px);
+  font-weight: 680;
+  letter-spacing: -0.05em;
+  line-height: 0.98;
+}
+
+.home-dashboard-intro > div > p:not(.eyebrow) {
+  max-width: 440px;
+  color: rgba(244, 241, 236, 0.66);
+  line-height: 1.5;
+}
+
+.home-continue-button {
+  margin-top: 20px;
+}
+
+.home-art-cluster {
+  position: relative;
+  width: min(100%, 360px);
+  aspect-ratio: 1;
+  justify-self: center;
+}
+
+.home-cluster-art,
+.home-cluster-empty {
+  position: absolute;
+  display: grid;
+  width: 48%;
+  aspect-ratio: 1;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  object-fit: cover;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.38);
+}
+
+.home-cluster-art-1 { left: 6%; top: 11%; transform: rotate(-12deg); }
+.home-cluster-art-2 { right: 4%; top: 4%; transform: rotate(9deg); }
+.home-cluster-art-3 { left: 25%; bottom: 1%; transform: rotate(-2deg); z-index: 2; }
+.home-cluster-art-4 { left: 1%; bottom: 14%; transform: rotate(17deg) scale(0.7); opacity: 0.72; }
+.home-cluster-art-5 { right: 3%; bottom: 14%; transform: rotate(-18deg) scale(0.7); opacity: 0.72; }
+
+.home-cluster-empty {
+  inset: 20%;
+  width: auto;
+  aspect-ratio: auto;
+  background: linear-gradient(135deg, rgba(240, 210, 123, 0.3), rgba(47, 145, 133, 0.3));
 }
 
 @media (max-width: 760px) {
+  .home-dashboard {
+    padding: 28px 22px;
+  }
+
+  .home-dashboard-intro {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .home-dashboard-intro > div > p:not(.eyebrow) {
+    margin-inline: auto;
+  }
+
+  .home-art-cluster {
+    width: min(280px, 76vw);
+    grid-row: 1;
+  }
+
   .home-now-playing-hero {
     grid-template-columns: 1fr;
     justify-items: center;
@@ -3823,6 +3878,31 @@ button.similar-chip:hover,
   object-fit: cover;
   background: rgba(255, 255, 255, 0.06);
   box-shadow: 0 12px 30px rgba(0, 0, 0, 0.32);
+}
+
+.player-now-playing-trigger {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  padding: 0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.player-now-playing-trigger svg {
+  position: absolute;
+  right: 5px;
+  bottom: 5px;
+  padding: 3px;
+  border-radius: 5px;
+  background: rgba(12, 12, 11, 0.76);
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+
+.player-now-playing-trigger:hover svg,
+.player-now-playing-trigger:focus-visible svg {
+  opacity: 1;
 }
 
 .now-playing-copy {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1295,64 +1295,13 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   gap: 20px;
 }
 
-.home-listening-ribbon {
-  display: grid;
-  gap: 10px;
-}
-
-.home-listening-ribbon .section-label,
-.home-now-playing-hero {
-  margin: 0;
-}
-
-.home-art-ribbon {
-  display: grid;
-  grid-template-columns: repeat(8, minmax(0, 1fr));
-  gap: 8px;
-  min-height: 68px;
-}
-
-.home-ribbon-album {
-  min-width: 0;
-  padding: 0;
-  overflow: hidden;
-  border-radius: 8px;
-  background: transparent;
-  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.18);
-  cursor: pointer;
-  transition: transform 160ms ease, filter 160ms ease;
-}
-
-.home-ribbon-album:hover {
-  filter: brightness(1.1);
-  transform: translateY(-3px);
-}
-
-.home-ribbon-album img,
-.home-ribbon-album .cover-fallback {
-  display: block;
-  width: 100%;
-  aspect-ratio: 1;
-  object-fit: cover;
-}
-
-.home-ribbon-empty {
-  grid-column: 1 / -1;
-  margin: 0;
-  padding: 18px;
-  border: 1px dashed rgba(244, 241, 236, 0.18);
-  border-radius: 8px;
-  color: rgba(244, 241, 236, 0.58);
-  font-size: 13px;
-}
-
 .home-now-playing-hero {
   position: relative;
   display: grid;
   grid-template-columns: minmax(160px, 0.52fr) minmax(0, 1fr);
   align-items: center;
   gap: clamp(22px, 4vw, 52px);
-  min-height: 340px;
+  min-height: min(560px, calc(100vh - 230px));
   padding: clamp(22px, 4vw, 42px);
   overflow: hidden;
   border-radius: 12px;
@@ -1467,14 +1416,6 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 }
 
 @media (max-width: 760px) {
-  .home-art-ribbon {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-
-  .home-ribbon-album:nth-child(n + 5) {
-    display: none;
-  }
-
   .home-now-playing-hero {
     grid-template-columns: 1fr;
     justify-items: center;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1295,6 +1295,206 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   gap: 20px;
 }
 
+.home-listening-ribbon {
+  display: grid;
+  gap: 10px;
+}
+
+.home-listening-ribbon .section-label,
+.home-now-playing-hero {
+  margin: 0;
+}
+
+.home-art-ribbon {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 8px;
+  min-height: 68px;
+}
+
+.home-ribbon-album {
+  min-width: 0;
+  padding: 0;
+  overflow: hidden;
+  border-radius: 8px;
+  background: transparent;
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.18);
+  cursor: pointer;
+  transition: transform 160ms ease, filter 160ms ease;
+}
+
+.home-ribbon-album:hover {
+  filter: brightness(1.1);
+  transform: translateY(-3px);
+}
+
+.home-ribbon-album img,
+.home-ribbon-album .cover-fallback {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+}
+
+.home-ribbon-empty {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: 18px;
+  border: 1px dashed rgba(244, 241, 236, 0.18);
+  border-radius: 8px;
+  color: rgba(244, 241, 236, 0.58);
+  font-size: 13px;
+}
+
+.home-now-playing-hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(160px, 0.52fr) minmax(0, 1fr);
+  align-items: center;
+  gap: clamp(22px, 4vw, 52px);
+  min-height: 340px;
+  padding: clamp(22px, 4vw, 42px);
+  overflow: hidden;
+  border-radius: 12px;
+  background:
+    radial-gradient(circle at 84% 12%, rgba(240, 210, 123, 0.22), transparent 34%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.035)),
+    rgba(255, 255, 255, 0.045);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 24px 70px rgba(0, 0, 0, 0.2);
+}
+
+.home-now-playing-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.055) 1px, transparent 1px), linear-gradient(30deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+  background-size: 34px 34px;
+  mask-image: linear-gradient(90deg, black, transparent 75%);
+  pointer-events: none;
+}
+
+.home-now-playing-art,
+.home-now-playing-copy {
+  position: relative;
+  z-index: 1;
+}
+
+.home-now-playing-art {
+  width: min(100%, 300px);
+  justify-self: center;
+  overflow: hidden;
+  border-radius: 10px;
+  box-shadow: 0 28px 54px rgba(0, 0, 0, 0.38);
+}
+
+.home-now-playing-art img,
+.home-now-playing-art .cover-fallback {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+}
+
+.home-now-playing-copy {
+  display: grid;
+  justify-items: start;
+  gap: 10px;
+  min-width: 0;
+}
+
+.home-now-playing-copy h3 {
+  max-width: 720px;
+  margin: 0;
+  overflow: hidden;
+  font-size: clamp(28px, 4vw, 48px);
+  font-weight: 680;
+  letter-spacing: -0.035em;
+  line-height: 1.02;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-now-playing-copy > p:not(.eyebrow) {
+  max-width: 560px;
+  margin: 0;
+  color: rgba(244, 241, 236, 0.7);
+}
+
+.home-playback-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.home-playback-controls button {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(244, 241, 236, 0.88);
+}
+
+.home-playback-controls button:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+}
+
+.home-playback-controls .home-primary-play {
+  width: 54px;
+  height: 54px;
+  background: #f0d27b;
+  color: #1b1815;
+  box-shadow: 0 10px 24px rgba(240, 210, 123, 0.2);
+}
+
+.home-seek-row {
+  display: grid;
+  width: min(100%, 580px);
+  grid-template-columns: 38px minmax(0, 1fr) 38px;
+  align-items: center;
+  gap: 9px;
+  margin-top: 8px;
+  color: rgba(244, 241, 236, 0.54);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.home-seek-row input {
+  width: 100%;
+}
+
+@media (max-width: 760px) {
+  .home-art-ribbon {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .home-ribbon-album:nth-child(n + 5) {
+    display: none;
+  }
+
+  .home-now-playing-hero {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    min-height: 0;
+  }
+
+  .home-now-playing-art {
+    width: min(220px, 70vw);
+  }
+
+  .home-now-playing-copy {
+    justify-items: center;
+    text-align: center;
+  }
+
+  .home-now-playing-copy h3 {
+    width: 100%;
+  }
+}
+
 .home-hero {
   position: relative;
   display: grid;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1454,6 +1454,8 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   flex: 1 1 auto;
   min-height: 0;
   padding: clamp(26px, 5vw, 72px);
+  align-content: start;
+  gap: clamp(28px, 4vw, 52px);
 }
 
 .home-dashboard-intro {
@@ -1482,6 +1484,115 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 
 .home-continue-button {
   margin-top: 20px;
+}
+
+.home-radio-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+  width: min(100%, 1040px);
+  margin: 0 auto;
+  padding: 18px 20px;
+  border: 1px solid rgba(171, 124, 255, 0.32);
+  border-radius: 16px;
+  background: linear-gradient(115deg, rgba(88, 50, 145, 0.3), rgba(21, 26, 43, 0.68));
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.2);
+}
+
+.home-radio-mark {
+  display: grid;
+  width: 46px;
+  aspect-ratio: 1;
+  place-items: center;
+  border-radius: 13px;
+  color: #f0ddff;
+  background: rgba(184, 127, 255, 0.18);
+}
+
+.home-radio-card h4,
+.home-shelf-heading h4 {
+  margin: 3px 0 4px;
+  font-size: 20px;
+  letter-spacing: -0.025em;
+}
+
+.home-radio-card p:not(.eyebrow) {
+  margin: 0;
+  color: rgba(244, 241, 236, 0.64);
+}
+
+.home-radio-button {
+  white-space: nowrap;
+}
+
+.home-album-shelf {
+  width: min(100%, 1040px);
+  margin: 0 auto;
+}
+
+.home-shelf-heading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.home-shelf-heading h4 {
+  margin-right: auto;
+}
+
+.home-shelf-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 0;
+  border: 0;
+  color: rgba(244, 241, 236, 0.62);
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.home-shelf-action:hover {
+  color: #fff;
+}
+
+.home-album-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.home-album {
+  display: grid;
+  min-width: 0;
+  gap: 6px;
+}
+
+.home-album-cover {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 10px;
+  object-fit: cover;
+}
+
+.home-album strong,
+.home-album small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-album strong {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.home-album small {
+  color: rgba(244, 241, 236, 0.56);
+  font-size: 12px;
 }
 
 .home-art-cluster {
@@ -1527,6 +1638,19 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
     text-align: center;
   }
 
+  .home-radio-card {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .home-radio-button {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+
+  .home-album-row {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .home-dashboard-intro > div > p:not(.eyebrow) {
     margin-inline: auto;
   }
@@ -1554,6 +1678,17 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 
   .home-now-playing-copy h3 {
     width: 100%;
+  }
+}
+
+@media (max-width: 460px) {
+  .home-radio-card {
+    align-items: start;
+    padding: 16px;
+  }
+
+  .home-album-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1551,6 +1551,16 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 }
 
 .home-shelf-heading h4 {
+  margin: 0;
+}
+
+.home-shelf-heading p {
+  margin: 4px 0 0;
+  color: rgba(244, 241, 236, 0.56);
+  font-size: 13px;
+}
+
+.home-shelf-heading > div {
   margin-right: auto;
 }
 
@@ -1573,19 +1583,33 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 
 .home-album-row {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 16px;
 }
 
 .home-album {
   display: grid;
+  grid-template-columns: 82px minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr) auto;
   min-width: 0;
-  gap: 6px;
+  gap: 4px 12px;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.035);
+  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.home-album:hover {
+  border-color: rgba(var(--prism-accent-rgb), 0.4);
+  background: rgba(var(--prism-accent-rgb), 0.08);
+  transform: translateY(-2px);
 }
 
 .home-album-cover {
   width: 100%;
   aspect-ratio: 1;
+  grid-row: 1 / span 2;
   border-radius: 10px;
   object-fit: cover;
 }
@@ -1598,11 +1622,13 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 }
 
 .home-album strong {
+  align-self: end;
   font-size: 14px;
   font-weight: 600;
 }
 
 .home-album small {
+  align-self: start;
   color: rgba(244, 241, 236, 0.56);
   font-size: 12px;
 }
@@ -1660,7 +1686,7 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   }
 
   .home-album-row {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: 1fr;
   }
 
   .home-dashboard-intro > div > p:not(.eyebrow) {
@@ -1700,7 +1726,7 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   }
 
   .home-album-row {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: 1fr;
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1607,6 +1607,7 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 }
 
 .home-album-row {
+  position: relative;
   display: grid;
   min-width: 0;
   width: 100%;
@@ -1622,6 +1623,27 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   scroll-snap-type: inline proximity;
   scrollbar-color: transparent transparent;
   scrollbar-width: thin;
+}
+
+/* macOS overlay scrollbars only reveal while actively scrolling. Keep a
+ * thumb-only cue visible on hover so horizontal shelves advertise themselves. */
+.home-album-row::after {
+  position: absolute;
+  right: 6px;
+  bottom: 1px;
+  width: 72px;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(244, 241, 236, 0.42);
+  content: "";
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 160ms ease;
+}
+
+.home-album-row:hover::after,
+.home-album-row:focus-visible::after {
+  opacity: 1;
 }
 
 .home-album-row::-webkit-scrollbar {
@@ -1668,9 +1690,14 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   transform: translateY(-2px);
 }
 
-.home-album-cover {
+.home-album > .playable-cover {
   width: 64px;
   flex: 0 0 64px;
+}
+
+.home-album-cover {
+  display: block;
+  width: 100%;
   aspect-ratio: 1;
   border-radius: 10px;
   object-fit: cover;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1476,7 +1476,10 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 .home-dashboard {
   display: grid;
   flex: 1 1 auto;
+  min-width: 0;
+  width: 100%;
   min-height: 0;
+  overflow-x: clip;
   padding: clamp(26px, 5vw, 72px);
   align-content: start;
   gap: clamp(28px, 4vw, 52px);
@@ -1561,6 +1564,7 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 
 .home-album-shelf {
   width: min(100%, 1040px);
+  min-width: 0;
   margin: 0 auto;
 }
 
@@ -1604,7 +1608,9 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 
 .home-album-row {
   display: grid;
-  grid-auto-columns: minmax(220px, 250px);
+  min-width: 0;
+  width: 100%;
+  grid-auto-columns: calc((100% - 24px) / 3);
   grid-auto-flow: column;
   grid-template-rows: 1fr;
   gap: 12px;
@@ -1634,7 +1640,7 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   display: flex;
   align-items: center;
   min-width: 0;
-  min-height: 76px;
+  min-height: 82px;
   gap: 10px;
   padding: 8px 10px 8px 8px;
   border: 1px solid rgba(255, 255, 255, 0.09);
@@ -1651,8 +1657,8 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 }
 
 .home-album-cover {
-  width: 60px;
-  flex: 0 0 60px;
+  width: 64px;
+  flex: 0 0 64px;
   aspect-ratio: 1;
   border-radius: 10px;
   object-fit: cover;
@@ -1675,7 +1681,7 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 
 .home-album-copy strong {
   -webkit-line-clamp: 2;
-  font-size: 12px;
+  font-size: 11px;
   line-height: 1.2;
   font-weight: 600;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,7 @@
 :root {
+  --prism-accent: #f0d27b;
+  --prism-accent-strong: #f8df91;
+  --prism-accent-rgb: 240, 210, 123;
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", system-ui, sans-serif;
   color: #f4f1ec;
   background: #111111;
@@ -1486,6 +1489,15 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   margin-top: 20px;
 }
 
+.home-continue-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 20px;
+  color: rgba(244, 241, 236, 0.72);
+  font-weight: 600;
+}
+
 .home-radio-card {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
@@ -1494,9 +1506,9 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   width: min(100%, 1040px);
   margin: 0 auto;
   padding: 18px 20px;
-  border: 1px solid rgba(171, 124, 255, 0.32);
+  border: 1px solid rgba(var(--prism-accent-rgb), 0.3);
   border-radius: 16px;
-  background: linear-gradient(115deg, rgba(88, 50, 145, 0.3), rgba(21, 26, 43, 0.68));
+  background: linear-gradient(115deg, rgba(var(--prism-accent-rgb), 0.2), rgba(21, 26, 43, 0.68));
   box-shadow: 0 16px 36px rgba(0, 0, 0, 0.2);
 }
 
@@ -1506,8 +1518,8 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   aspect-ratio: 1;
   place-items: center;
   border-radius: 13px;
-  color: #f0ddff;
-  background: rgba(184, 127, 255, 0.18);
+  color: var(--prism-accent-strong);
+  background: rgba(var(--prism-accent-rgb), 0.18);
 }
 
 .home-radio-card h4,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1325,6 +1325,27 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
     linear-gradient(135deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012));
 }
 
+.home-cover-wash {
+  position: absolute;
+  inset: -16%;
+  z-index: 0;
+  pointer-events: none;
+  background-position: center;
+  background-size: cover;
+  opacity: 0.58;
+  filter: blur(46px) saturate(145%);
+  transform: scale(1.08);
+}
+
+.home-cover-wash::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background:
+    linear-gradient(112deg, rgba(13, 13, 12, 0.48), rgba(13, 13, 12, 0.68) 58%, rgba(13, 13, 12, 0.5)),
+    radial-gradient(circle at 78% 20%, rgba(240, 210, 123, 0.12), transparent 44%);
+}
+
 .home-now-playing-hero::after {
   content: "";
   position: absolute;

--- a/src/styles.css
+++ b/src/styles.css
@@ -3262,7 +3262,8 @@ button.similar-chip:hover,
   display: -webkit-box;
   overflow-wrap: anywhere;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 4;
+  /* Three lines is the hard visual limit; the full title remains available to assistive tech. */
+  -webkit-line-clamp: 3;
   margin-top: 10px;
   color: #f4f1ec;
   font-size: clamp(36px, 9cqw, 48px);
@@ -4138,8 +4139,8 @@ button.similar-chip:hover,
   padding: 8px 18px 10px;
   border-top: 1px solid rgba(255, 255, 255, 0.1);
   background:
-    linear-gradient(90deg, rgba(240, 210, 123, 0.08), transparent 28%, rgba(63, 145, 133, 0.07)),
-    rgba(7, 7, 7, 0.82);
+    linear-gradient(90deg, rgba(240, 210, 123, 0.1), transparent 28%, rgba(63, 145, 133, 0.09)),
+    rgba(7, 7, 7, 0.56);
   backdrop-filter: blur(20px);
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -2785,6 +2785,12 @@ button.similar-chip:hover,
   color: #f8df91;
 }
 
+.settings-station-details {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
 .settings-station-main {
   display: grid;
   grid-template-columns: 20px minmax(0, 1fr);
@@ -2809,6 +2815,18 @@ button.similar-chip:hover,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.settings-station-name {
+  width: 100%;
+  min-height: 28px;
+  padding: 4px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.12);
+  color: inherit;
+  font: inherit;
+  font-size: 0.78rem;
 }
 
 .settings-station-form {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1606,8 +1606,11 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   color: #fff;
 }
 
-.home-album-row {
+.home-album-carousel {
   position: relative;
+}
+
+.home-album-row {
   display: grid;
   min-width: 0;
   width: 100%;
@@ -1625,25 +1628,57 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   scrollbar-width: thin;
 }
 
-/* macOS overlay scrollbars only reveal while actively scrolling. Keep a
- * thumb-only cue visible on hover so horizontal shelves advertise themselves. */
-.home-album-row::after {
+.home-album-scrollbar {
   position: absolute;
-  right: 6px;
+  right: 1px;
+  left: 1px;
   bottom: 1px;
-  width: 72px;
-  height: 4px;
-  border-radius: 999px;
-  background: rgba(244, 241, 236, 0.42);
-  content: "";
+  width: calc(100% - 2px);
+  height: 8px;
+  margin: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  cursor: ew-resize;
   opacity: 0;
   pointer-events: none;
   transition: opacity 160ms ease;
 }
 
-.home-album-row:hover::after,
-.home-album-row:focus-visible::after {
+.home-album-carousel:hover .home-album-scrollbar,
+.home-album-carousel:focus-within .home-album-scrollbar {
   opacity: 1;
+  pointer-events: auto;
+}
+
+.home-album-scrollbar::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 999px;
+  background: transparent;
+}
+
+.home-album-scrollbar::-webkit-slider-thumb {
+  width: 72px;
+  height: 4px;
+  margin-top: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(244, 241, 236, 0.42);
+}
+
+.home-album-scrollbar::-moz-range-track {
+  height: 4px;
+  background: transparent;
+}
+
+.home-album-scrollbar::-moz-range-thumb {
+  width: 72px;
+  height: 4px;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(244, 241, 236, 0.42);
 }
 
 .home-album-row::-webkit-scrollbar {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1604,20 +1604,43 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 
 .home-album-row {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
+  grid-auto-columns: minmax(220px, 250px);
+  grid-auto-flow: column;
+  grid-template-rows: 1fr;
+  gap: 12px;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  padding: 1px 1px 8px;
+  scroll-padding-inline: 1px;
+  scroll-snap-type: inline proximity;
+  scrollbar-color: rgba(244, 241, 236, 0.42) transparent;
+  scrollbar-width: thin;
+}
+
+.home-album-row::-webkit-scrollbar {
+  height: 6px;
+}
+
+.home-album-row::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.home-album-row::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: rgba(244, 241, 236, 0.36);
 }
 
 .home-album {
   display: flex;
   align-items: center;
   min-width: 0;
-  min-height: 104px;
-  gap: 14px;
-  padding: 10px 14px 10px 10px;
+  min-height: 76px;
+  gap: 10px;
+  padding: 8px 10px 8px 8px;
   border: 1px solid rgba(255, 255, 255, 0.09);
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.035);
+  scroll-snap-align: start;
   transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
 }
 
@@ -1628,8 +1651,8 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 }
 
 .home-album-cover {
-  width: 84px;
-  flex: 0 0 84px;
+  width: 60px;
+  flex: 0 0 60px;
   aspect-ratio: 1;
   border-radius: 10px;
   object-fit: cover;
@@ -1637,8 +1660,9 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 
 .home-album-copy {
   display: grid;
+  flex: 1 1 auto;
   min-width: 0;
-  gap: 4px;
+  gap: 2px;
 }
 
 .home-album-copy strong,
@@ -1651,16 +1675,16 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 
 .home-album-copy strong {
   -webkit-line-clamp: 2;
-  font-size: 13px;
-  line-height: 1.25;
+  font-size: 12px;
+  line-height: 1.2;
   font-weight: 600;
 }
 
 .home-album-copy small {
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 1;
   color: rgba(244, 241, 236, 0.56);
-  font-size: 11px;
-  line-height: 1.3;
+  font-size: 10px;
+  line-height: 1.2;
 }
 
 .home-art-cluster {
@@ -1716,7 +1740,7 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   }
 
   .home-album-row {
-    grid-template-columns: 1fr;
+    grid-auto-columns: minmax(210px, 78vw);
   }
 
   .home-dashboard-intro > div > p:not(.eyebrow) {
@@ -1756,7 +1780,7 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   }
 
   .home-album-row {
-    grid-template-columns: 1fr;
+    grid-auto-columns: minmax(200px, 84vw);
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1082,7 +1082,28 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   border: 0;
   border-radius: 0;
   background: transparent;
-  overflow: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: transparent transparent;
+}
+
+.browser-panel.home-panel::-webkit-scrollbar {
+  width: 10px;
+}
+
+.browser-panel.home-panel::-webkit-scrollbar-thumb {
+  background: transparent;
+}
+
+.browser-panel.home-panel.is-scrolling {
+  scrollbar-color: rgba(244, 241, 236, 0.34) transparent;
+}
+
+.browser-panel.home-panel.is-scrolling::-webkit-scrollbar-thumb {
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background: rgba(244, 241, 236, 0.34);
+  background-clip: padding-box;
 }
 
 .browser-heading {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1604,17 +1604,17 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 
 .home-album-row {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
 }
 
 .home-album {
-  display: grid;
-  grid-template-columns: 82px minmax(0, 1fr);
-  grid-template-rows: minmax(0, 1fr) auto;
+  display: flex;
+  align-items: center;
   min-width: 0;
-  gap: 4px 12px;
-  padding: 10px;
+  min-height: 104px;
+  gap: 14px;
+  padding: 10px 14px 10px 10px;
   border: 1px solid rgba(255, 255, 255, 0.09);
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.035);
@@ -1628,30 +1628,39 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 }
 
 .home-album-cover {
-  width: 100%;
+  width: 84px;
+  flex: 0 0 84px;
   aspect-ratio: 1;
-  grid-row: 1 / span 2;
   border-radius: 10px;
   object-fit: cover;
 }
 
-.home-album strong,
-.home-album small {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.home-album-copy {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
 }
 
-.home-album strong {
-  align-self: end;
-  font-size: 14px;
+.home-album-copy strong,
+.home-album-copy small {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow-wrap: anywhere;
+}
+
+.home-album-copy strong {
+  -webkit-line-clamp: 2;
+  font-size: 13px;
+  line-height: 1.25;
   font-weight: 600;
 }
 
-.home-album small {
-  align-self: start;
+.home-album-copy small {
+  -webkit-line-clamp: 2;
   color: rgba(244, 241, 236, 0.56);
-  font-size: 12px;
+  font-size: 11px;
+  line-height: 1.3;
 }
 
 .home-art-cluster {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1606,6 +1606,10 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   color: #fff;
 }
 
+.home-album-carousel {
+  position: relative;
+}
+
 .home-album-row {
   display: grid;
   min-width: 0;
@@ -1622,6 +1626,24 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   scroll-snap-type: inline proximity;
   scrollbar-color: transparent transparent;
   scrollbar-width: thin;
+}
+
+.home-album-scroll-cue {
+  position: absolute;
+  top: 50%;
+  z-index: 1;
+  color: rgba(244, 241, 236, 0.5);
+  filter: drop-shadow(0 1px 5px rgba(0, 0, 0, 0.5));
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.home-album-scroll-cue-left {
+  left: -2px;
+}
+
+.home-album-scroll-cue-right {
+  right: -2px;
 }
 
 .home-album-row::-webkit-scrollbar {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1606,10 +1606,6 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   color: #fff;
 }
 
-.home-album-carousel {
-  position: relative;
-}
-
 .home-album-row {
   display: grid;
   min-width: 0;
@@ -1620,65 +1616,12 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   gap: 12px;
   overflow-x: auto;
   overscroll-behavior-inline: contain;
-  /* Leave room for the card lift and the carousel affordance without clipping either. */
+  /* Leave room for the card lift and native scrollbar without clipping either. */
   padding: 6px 1px 10px;
   scroll-padding-inline: 1px;
   scroll-snap-type: inline proximity;
   scrollbar-color: transparent transparent;
   scrollbar-width: thin;
-}
-
-.home-album-scrollbar {
-  position: absolute;
-  right: 1px;
-  left: 1px;
-  bottom: 1px;
-  width: calc(100% - 2px);
-  height: 8px;
-  margin: 0;
-  appearance: none;
-  -webkit-appearance: none;
-  background: transparent;
-  cursor: ew-resize;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 160ms ease;
-}
-
-.home-album-carousel:hover .home-album-scrollbar,
-.home-album-carousel:focus-within .home-album-scrollbar {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.home-album-scrollbar::-webkit-slider-runnable-track {
-  height: 4px;
-  border-radius: 999px;
-  background: transparent;
-}
-
-.home-album-scrollbar::-webkit-slider-thumb {
-  width: 72px;
-  height: 4px;
-  margin-top: 0;
-  appearance: none;
-  -webkit-appearance: none;
-  border: 0;
-  border-radius: 999px;
-  background: rgba(244, 241, 236, 0.42);
-}
-
-.home-album-scrollbar::-moz-range-track {
-  height: 4px;
-  background: transparent;
-}
-
-.home-album-scrollbar::-moz-range-thumb {
-  width: 72px;
-  height: 4px;
-  border: 0;
-  border-radius: 999px;
-  background: rgba(244, 241, 236, 0.42);
 }
 
 .home-album-row::-webkit-scrollbar {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1616,10 +1616,11 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   gap: 12px;
   overflow-x: auto;
   overscroll-behavior-inline: contain;
-  padding: 1px 1px 8px;
+  /* Leave room for the card lift and the carousel affordance without clipping either. */
+  padding: 6px 1px 10px;
   scroll-padding-inline: 1px;
   scroll-snap-type: inline proximity;
-  scrollbar-color: rgba(244, 241, 236, 0.42) transparent;
+  scrollbar-color: transparent transparent;
   scrollbar-width: thin;
 }
 
@@ -1633,6 +1634,17 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 
 .home-album-row::-webkit-scrollbar-thumb {
   border-radius: 999px;
+  background: transparent;
+  transition: background 160ms ease;
+}
+
+.home-album-row:hover,
+.home-album-row:focus-visible {
+  scrollbar-color: rgba(244, 241, 236, 0.42) transparent;
+}
+
+.home-album-row:hover::-webkit-scrollbar-thumb,
+.home-album-row:focus-visible::-webkit-scrollbar-thumb {
   background: rgba(244, 241, 236, 0.36);
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1073,6 +1073,15 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   overflow: auto;
 }
 
+.browser-panel.home-panel {
+  display: flex;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  overflow: hidden;
+}
+
 .browser-heading {
   position: sticky;
   top: -14px;
@@ -1291,8 +1300,12 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 }
 
 .home-view {
-  display: grid;
-  gap: 20px;
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  height: calc(100vh - 166px);
+  max-height: calc(100vh - 166px);
+  overflow: hidden;
 }
 
 .home-now-playing-hero {
@@ -1301,15 +1314,15 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   grid-template-columns: minmax(160px, 0.52fr) minmax(0, 1fr);
   align-items: center;
   gap: clamp(22px, 4vw, 52px);
-  min-height: min(560px, calc(100vh - 230px));
+  width: 100%;
+  min-height: 0;
+  height: 100%;
   padding: clamp(22px, 4vw, 42px);
   overflow: hidden;
-  border-radius: 12px;
+  border-radius: 0;
   background:
-    radial-gradient(circle at 84% 12%, rgba(240, 210, 123, 0.22), transparent 34%),
-    linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.035)),
-    rgba(255, 255, 255, 0.045);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 24px 70px rgba(0, 0, 0, 0.2);
+    radial-gradient(circle at 84% 12%, rgba(240, 210, 123, 0.16), transparent 38%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012));
 }
 
 .home-now-playing-hero::after {
@@ -1329,7 +1342,7 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 }
 
 .home-now-playing-art {
-  width: min(100%, 300px);
+  width: min(100%, 38vh, 360px);
   justify-self: center;
   overflow: hidden;
   border-radius: 10px;
@@ -1420,6 +1433,7 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
     grid-template-columns: 1fr;
     justify-items: center;
     min-height: 0;
+    padding: 18px;
   }
 
   .home-now-playing-art {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1356,6 +1356,10 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   pointer-events: none;
 }
 
+.home-now-playing-hero.is-radio {
+  grid-template-columns: minmax(180px, 0.6fr) minmax(0, 1fr);
+}
+
 .home-now-playing-art,
 .home-now-playing-copy {
   position: relative;
@@ -1368,6 +1372,16 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   overflow: hidden;
   border-radius: 10px;
   box-shadow: 0 28px 54px rgba(0, 0, 0, 0.38);
+}
+
+.home-now-playing-hero.is-radio .home-now-playing-art {
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.12), 0 32px 80px rgba(0, 0, 0, 0.48);
+}
+
+.home-now-playing-hero.is-radio .home-now-playing-art img,
+.home-now-playing-hero.is-radio .home-now-playing-art .cover-fallback {
+  border-radius: inherit;
 }
 
 .home-now-playing-art img,
@@ -1447,6 +1461,23 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
 
 .home-seek-row input {
   width: 100%;
+}
+
+.home-radio-status {
+  margin: 8px 0 0;
+  color: rgba(244, 241, 236, 0.58);
+  font-size: 12px;
+}
+
+.home-radio-status::before {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  margin-right: 7px;
+  border-radius: 50%;
+  background: #ef7868;
+  box-shadow: 0 0 14px rgba(239, 120, 104, 0.7);
+  content: "";
 }
 
 @media (max-width: 760px) {


### PR DESCRIPTION
## Outcome

Makes Prism Home a music discovery dashboard, while keeping local Now Playing and Subwave Radio as separate focused experiences.

## Changes

- Adds a time-aware greeting and Continue Listening entry point to Home.
- Adds a distinct Radio doorway without mixing live station state into local-library playback.
- Adds Recently Played, Recently Added, and refreshable Shuffle Something album shelves.
- Keeps local full Now Playing accessible from the player-bar artwork rather than a permanent sidebar destination.

## Validation

- `npm run lint`
- `npm run build` (includes typecheck)
- Feature preview responds at `http://10.10.10.11:1420/` from this branch.

## Notes

No deployment is included. The sidebar Radio item remains the dedicated station and booth destination.
