### PR TITLE
fix: Make track-row play icons receive clicks

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -2140,6 +2140,10 @@ button.similar-chip:hover,
   grid-area: 1 / 1;
 }
 
+.track-index .track-number {
+  pointer-events: none;
+}
+
 .album-track-row:hover .track-number,
 .album-track-row:focus-within .track-number {
   opacity: 0;


### PR DESCRIPTION
## Summary

Fixes #94 by letting the visible track-row play button receive clicks across its full icon area.

The track number and play button intentionally share the same grid cell. On hover, the number faded out but continued to intercept pointer events over the middle of the play icon. The track number now ignores pointer input, so the button receives the click as intended.

## Validation

- `npm run build`
- `npm run lint`
- Isolated Vite preview responded on port 1421

## Risk and rollback

Low-risk CSS-only change scoped to the overlapping album track-row number. Revert commit `58597ee` to roll back.
