### PR TITLE
fix: Clear Discord presence when playback stops

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3287,7 +3287,7 @@ export function App() {
     }
 
     const radioPresence = activePlaybackSource === "radio" && isRadioPlaying && radioNowPlaying;
-    const localPresence = activePlaybackSource === "local" && currentTrack;
+    const localPresence = activePlaybackSource === "local" && isPlaying && currentTrack;
 
     if (!radioPresence && !localPresence) {
       setDiscordPresenceStatus("idle");


### PR DESCRIPTION
## Summary

- Clear Discord Rich Presence when local playback is stopped or paused.
- Keep presence active only while local audio is actually playing.

Closes #107

## Validation

- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Risk and rollback

This changes only the local-presence eligibility check. Radio presence is unchanged. Revert commit `f52387f` if needed.
