### PR TITLE
fix: Keep Now Playing titles and progress aligned

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6819,6 +6819,8 @@ function NowPlayingView({
       ? "Pick an album, artist, or song from your library."
       : "Connect your Navidrome server to bring your music home.";
   const progress = Math.min(position, Math.max(duration, 1));
+  const progressRatio = progress / Math.max(duration, 1);
+  const progressFillEnd = `calc(11px + ${progressRatio * 100}% - ${22 * progressRatio}px)`;
 
   return (
     <div className="home-view">
@@ -6842,7 +6844,18 @@ function NowPlayingView({
           </div>
           <div className="home-seek-row">
             <span>{formatDuration(position)}</span>
-            <input type="range" min="0" max={Math.max(duration, 1)} step="1" value={progress} onChange={(event) => onSeek(Number(event.target.value))} disabled={!hasTrack || !duration} aria-label="Seek" />
+            <input
+              className="home-seek-slider"
+              type="range"
+              min="0"
+              max={Math.max(duration, 1)}
+              step="1"
+              value={progress}
+              style={{ "--home-seek-fill-end": progressFillEnd } as CSSProperties}
+              onChange={(event) => onSeek(Number(event.target.value))}
+              disabled={!hasTrack || !duration}
+              aria-label="Seek"
+            />
             <span>{formatDuration(duration)}</span>
           </div>
         </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1417,8 +1417,10 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   font-weight: 680;
   letter-spacing: -0.035em;
   line-height: 1.02;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .home-now-playing-copy > p:not(.eyebrow) {
@@ -1469,8 +1471,68 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   font-variant-numeric: tabular-nums;
 }
 
-.home-seek-row input {
+.home-seek-slider {
+  appearance: none;
   width: 100%;
+  min-height: 18px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: linear-gradient(
+    to right,
+    var(--prism-accent) 0 var(--home-seek-fill-end, 11px),
+    rgba(244, 241, 236, 0.28) var(--home-seek-fill-end, 11px) 100%
+  );
+  box-shadow: none;
+  cursor: pointer;
+}
+
+.home-seek-slider::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 999px;
+  background: transparent;
+}
+
+.home-seek-slider::-webkit-slider-thumb {
+  width: 22px;
+  height: 22px;
+  margin-top: -8px;
+  appearance: none;
+  border: 1px solid rgba(27, 24, 21, 0.12);
+  border-radius: 50%;
+  background: var(--prism-accent-strong);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.24);
+}
+
+.home-seek-slider::-moz-range-track {
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(244, 241, 236, 0.28);
+}
+
+.home-seek-slider::-moz-range-progress {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--prism-accent);
+}
+
+.home-seek-slider::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border: 1px solid rgba(27, 24, 21, 0.12);
+  border-radius: 50%;
+  background: var(--prism-accent-strong);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.24);
+}
+
+.home-seek-slider:disabled {
+  cursor: default;
+  opacity: 0.42;
+}
+
+.home-seek-slider:focus-visible {
+  outline: 2px solid rgba(var(--prism-accent-rgb), 0.72);
+  outline-offset: 3px;
 }
 
 .home-dashboard {


### PR DESCRIPTION
## Summary

- Wrap long Now Playing titles across up to two lines, including unbroken titles.
- Use Prism theme tokens for the seek track and thumb.
- Align the filled track endpoint with the native slider thumb throughout its travel.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Feature preview responds at `http://10.10.10.11:1420/`

## Risk and rollback

UI-only change. Revert commit `b7ef06f` to restore the previous single-line title and native range styling.
