### PR TITLE
feat: Add native playback controls and window restoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Prism checks that the address is a Subwave station before connecting. You can sa
 
 Once you're tuned in, Prism shows what is playing and keeps the station controls close by. Use the request button when you want to send something to the station.
 
+## Desktop controls
+
+The installed desktop app restores its last usable window size, position, and maximized state when it opens again. It also listens for your system media play/pause, next, and previous keys while Prism is in the background. Next and previous apply only to library playback; live Subwave radio correctly ignores them.
+
+Prism can show a native notification when playback or radio needs attention, and for track changes while the app is not in the foreground. Notification permission is requested by the operating system the first time it is needed and can be changed later in system settings. Browser previews keep working without native window restoration, global media keys, or native notifications.
+
 ## Status
 
 Prism is pre-1.0 software. If something is broken or you have an idea, open a [GitHub issue](https://github.com/kylejschultz/prism-player/issues).

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-dropdown-menu": "^2.1.24",
         "@tauri-apps/api": "^2.8.0",
+        "@tauri-apps/plugin-global-shortcut": "^2.3.2",
+        "@tauri-apps/plugin-notification": "^2.3.3",
         "lucide-react": "^1.31.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
@@ -1415,6 +1417,24 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-global-shortcut": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-global-shortcut/-/plugin-global-shortcut-2.3.2.tgz",
+      "integrity": "sha512-UReHNXrLvpEjylE4jb4oCYiy96uRykPUthoCQCmRXYrd5hs5X9DrW+qOn7GLW57EJN4tdK8bgK5twBTz2NOxzA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-notification": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
+      "integrity": "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@types/esrecurse": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@tauri-apps/api": "^2.8.0",
+    "@tauri-apps/plugin-global-shortcut": "^2.3.2",
+    "@tauri-apps/plugin-notification": "^2.3.3",
     "lucide-react": "^1.31.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
 dependencies = [
  "byteorder",
  "fnv",
- "uuid 1.24.1",
+ "uuid 1.25.0",
 ]
 
 [[package]]
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1308,6 +1308,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1435,24 @@ name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.20",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -2118,9 +2146,23 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid 1.25.0",
+]
 
 [[package]]
 name = "markup5ever"
@@ -2225,6 +2267,20 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
 
 [[package]]
 name = "num"
@@ -2449,6 +2505,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2774,6 +2831,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,7 +2855,10 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-global-shortcut",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
+ "tauri-plugin-window-state",
 ]
 
 [[package]]
@@ -2883,6 +2952,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -3048,7 +3146,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
- "uuid 1.24.1",
+ "uuid 1.25.0",
 ]
 
 [[package]]
@@ -3702,7 +3800,7 @@ dependencies = [
  "thiserror 2.0.20",
  "time",
  "url",
- "uuid 1.24.1",
+ "uuid 1.25.0",
  "walkdir",
 ]
 
@@ -3737,6 +3835,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9f4c5136c09cd962da0c86dc4accd4666db2ea591cf16e6597435843bd2b"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3756,6 +3888,21 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.13.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3843,7 +3990,7 @@ dependencies = [
  "toml 1.1.4+spec-1.1.0",
  "url",
  "urlpattern",
- "uuid 1.24.1",
+ "uuid 1.25.0",
  "walkdir",
 ]
 
@@ -3856,6 +4003,17 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.4+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.20",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]
@@ -4344,9 +4502,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -5066,6 +5224,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5115,7 +5296,7 @@ dependencies = [
  "serde_repr",
  "tracing",
  "uds_windows",
- "uuid 1.24.1",
+ "uuid 1.25.0",
  "windows-sys 0.61.2",
  "winnow 1.0.4",
  "zbus_macros",
@@ -5167,6 +5348,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,4 +18,7 @@ keyring = "4.1.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }
+tauri-plugin-global-shortcut = "2"
+tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"
+tauri-plugin-window-state = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,11 @@
   "identifier": "default",
   "description": "Default desktop app permissions.",
   "windows": ["main"],
-  "permissions": ["core:default", "opener:default"]
+  "permissions": [
+    "core:default",
+    "opener:default",
+    "global-shortcut:default",
+    "notification:default",
+    "window-state:default"
+  ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -167,7 +167,10 @@ fn clear_discord_presence_in_background(app: &tauri::AppHandle) {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
+        .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_window_state::Builder::default().build())
         .manage(DiscordPresenceClient::default())
         .invoke_handler(tauri::generate_handler![
             update_discord_presence,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { register, unregister } from "@tauri-apps/plugin-global-shortcut";
+import { isPermissionGranted, requestPermission, sendNotification } from "@tauri-apps/plugin-notification";
 import type { CSSProperties, FormEvent, KeyboardEvent as ReactKeyboardEvent, MouseEvent, PointerEvent as ReactPointerEvent, ReactNode } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import * as AlertDialog from "@radix-ui/react-alert-dialog";
@@ -69,6 +71,13 @@ type SongSortKey = "title" | "artist" | "album" | "duration" | "track";
 type SongSortDirection = "asc" | "desc";
 
 const LIBRARY_SCAN_POLL_INTERVAL_MS = 5 * 60 * 1000;
+const MEDIA_SHORTCUTS = [
+  ["MediaPlayPause", "toggle"],
+  ["MediaTrackNext", "next"],
+  ["MediaTrackPrevious", "previous"],
+] as const;
+
+type MediaShortcutAction = (typeof MEDIA_SHORTCUTS)[number][1];
 
 function PrismDialog({
   open,
@@ -146,6 +155,10 @@ function isVersionNewer(candidate: string, current: string) {
 
 function isTauriDesktopApp() {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+function isAppForegrounded() {
+  return document.visibilityState === "visible" && document.hasFocus();
 }
 
 type NavidromeConfig = {
@@ -2004,6 +2017,9 @@ export function App() {
   const libraryScanCheckInFlightRef = useRef(false);
   const libraryRefreshInFlightRef = useRef(false);
   const libraryRefreshGenerationRef = useRef(0);
+  const desktopNotificationTimesRef = useRef(new Map<string, number>());
+  const mediaShortcutHandlerRef = useRef<(action: MediaShortcutAction) => void>(() => undefined);
+  const lastBackgroundTrackRef = useRef<string | null>(null);
   const [discordPresenceSyncNonce, setDiscordPresenceSyncNonce] = useState(0);
   const [discordPresenceStatus, setDiscordPresenceStatus] = useState<DiscordPresenceStatus>("idle");
 
@@ -2034,6 +2050,27 @@ export function App() {
       .sort((a, b) => a.name.localeCompare(b.name)),
     [config?.username, libraryData.playlists],
   );
+
+  async function notifyDesktop(key: string, title: string, body: string, cooldownMs = 15_000) {
+    if (!isTauriDesktopApp() || isAppForegrounded()) return;
+
+    const now = Date.now();
+    const lastNotification = desktopNotificationTimesRef.current.get(key) ?? 0;
+    if (now - lastNotification < cooldownMs) return;
+
+    try {
+      let granted = await isPermissionGranted();
+      if (!granted) granted = (await requestPermission()) === "granted";
+      if (!granted) return;
+      if (isAppForegrounded()) return;
+
+      desktopNotificationTimesRef.current.set(key, now);
+      sendNotification({ title, body });
+    } catch {
+      // Native notifications are optional: preview builds and restricted OS
+      // notification settings must never interrupt playback.
+    }
+  }
   const coverWashUrl = appSettings.coverWashEnabled && visualEffectsEnabled
     ? isRadioPlaying
       ? radioCoverUrl
@@ -3335,6 +3372,21 @@ export function App() {
     setIsPlaying(true);
   }
 
+  mediaShortcutHandlerRef.current = (action) => {
+    if (action === "toggle") {
+      togglePlayback();
+      return;
+    }
+
+    // Live radio has no meaningful next/previous track control. Returning
+    // here also prevents a media key from changing a paused local queue
+    // behind an active Subwave session.
+    if (activePlaybackSource === "radio" && radioStationUrl) return;
+
+    if (action === "next") playNext(false);
+    if (action === "previous") playPrevious();
+  };
+
   function setPlayerVolume(nextVolume: number) {
     const clampedVolume = Math.min(1, Math.max(0, nextVolume));
     const audio = audioRef.current;
@@ -3972,6 +4024,37 @@ export function App() {
   }, [currentTrack?.duration, playerDuration, position, queue.length, isPlaying, currentStreamUrl, isRadioPlaying]);
 
   useEffect(() => {
+    if (!isTauriDesktopApp()) return;
+
+    let active = true;
+    const registeredShortcuts: string[] = [];
+
+    void (async () => {
+      for (const [shortcut, action] of MEDIA_SHORTCUTS) {
+        try {
+          await register(shortcut, (event) => {
+            if (event.state === "Pressed") mediaShortcutHandlerRef.current(action);
+          });
+
+          if (!active) {
+            void unregister(shortcut).catch(() => undefined);
+            continue;
+          }
+          registeredShortcuts.push(shortcut);
+        } catch {
+          // Another app or the operating system may reserve a media key.
+          // Prism continues to expose the same controls in its player UI.
+        }
+      }
+    })();
+
+    return () => {
+      active = false;
+      void Promise.all(registeredShortcuts.map((shortcut) => unregister(shortcut).catch(() => undefined)));
+    };
+  }, []);
+
+  useEffect(() => {
     if (!("mediaSession" in navigator)) return;
 
     const controlsRadio = activePlaybackSource === "radio" && Boolean(radioStationUrl);
@@ -4033,6 +4116,37 @@ export function App() {
       navigator.mediaSession.setActionHandler("seekforward", null);
     };
   }, [activePlaybackSource, currentTrack, currentTrackCoverUrl, isPlaying, isRadioPlaying, playerDuration, position, radioCoverUrl, radioNowPlaying, radioStationUrl]);
+
+  useEffect(() => {
+    const activeRadio = activePlaybackSource === "radio" && radioStationUrl;
+    const trackKey = activeRadio
+      ? radioNowPlaying
+        ? `radio:${radioStationUrl}:${radioNowPlaying.subsonic_id ?? radioNowPlaying.title ?? "unknown"}`
+        : null
+      : isPlaying && currentTrack
+        ? `local:${currentTrack.id}`
+        : null;
+
+    if (!trackKey) return;
+
+    const previousTrackKey = lastBackgroundTrackRef.current;
+    lastBackgroundTrackRef.current = trackKey;
+    if (!previousTrackKey || previousTrackKey === trackKey) return;
+
+    const title = activeRadio ? radioNowPlaying?.title ?? "Subwave Radio" : currentTrack?.title ?? "Now playing";
+    const artist = activeRadio ? radioNowPlaying?.artist ?? "Subwave" : currentTrack?.artist ?? "Unknown artist";
+    void notifyDesktop("track-change", title, artist, 2_000);
+  }, [activePlaybackSource, currentTrack, isPlaying, radioNowPlaying, radioStationUrl]);
+
+  useEffect(() => {
+    if (!playerError) return;
+    void notifyDesktop("playback-error", "Playback needs attention", playerError);
+  }, [playerError]);
+
+  useEffect(() => {
+    if (radioStatus !== "error") return;
+    void notifyDesktop("radio-error", "Subwave needs attention", radioMessage || "The station could not keep playing.");
+  }, [radioMessage, radioStatus]);
 
   useEffect(() => {
     const trimmedQuery = searchQuery.trim();


### PR DESCRIPTION
## Outcome

Gives installed Prism builds native window restoration, global media controls, and restrained desktop notifications without changing browser-preview behavior.

## What changed

- Registers Tauri v2 Window State to restore a usable prior size, position, and maximized state.
- Registers global Media Play/Pause, Next, and Previous shortcuts.
  - Play/Pause follows the active local or Subwave session.
  - Next/Previous are ignored while Subwave is active, so they never advance an inactive local queue.
- Adds permission-aware, background-only native notifications for track changes and playback/radio failures, with cooldowns to prevent spam.
- Documents the desktop-only behavior and preview fallback.

## Validation

- `npm test`
- `npm run build`
- `cargo check`
- `cargo test`
- `npm run tauri:build:app` (macOS app bundle produced)

## Notes and rollback

- Browser/Vite preview is intentionally a no-op for all native APIs.
- A media key reserved by another application or the OS leaves Prism's in-app controls unaffected.
- `cargo fmt` and `cargo clippy` could not run because their Rust toolchain components are not installed on this host.
- Roll back by reverting this single commit; no persisted application-data migration is involved.
