### PR TITLE
refactor: Cache Navidrome server data with TanStack Query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-context-menu": "^2.3.7",
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-dropdown-menu": "^2.1.24",
+        "@tanstack/react-query": "^5.101.4",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-global-shortcut": "^2.3.2",
         "@tauri-apps/plugin-notification": "^2.3.3",
@@ -1176,6 +1177,32 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@tauri-apps/api": {
       "version": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-context-menu": "^2.3.7",
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-dropdown-menu": "^2.1.24",
+    "@tanstack/react-query": "^5.101.4",
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-global-shortcut": "^2.3.2",
     "@tauri-apps/plugin-notification": "^2.3.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { register, unregister } from "@tauri-apps/plugin-global-shortcut";
 import { isPermissionGranted, requestPermission, sendNotification } from "@tauri-apps/plugin-notification";
+import { useQueryClient } from "@tanstack/react-query";
+import { navidromeClient, navidromeKeys } from "./data/navidrome";
 import type { CSSProperties, FormEvent, KeyboardEvent as ReactKeyboardEvent, MouseEvent, PointerEvent as ReactPointerEvent, ReactNode } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import * as AlertDialog from "@radix-ui/react-alert-dialog";
@@ -161,7 +163,7 @@ function isAppForegrounded() {
   return document.visibilityState === "visible" && document.hasFocus();
 }
 
-type NavidromeConfig = {
+export type NavidromeConfig = {
   serverUrl: string;
   username: string;
   password: string;
@@ -188,7 +190,7 @@ type AppSettings = {
   radioStationNames: Record<string, string>;
 };
 
-type Album = {
+export type Album = {
   id: string;
   name: string;
   artist: string;
@@ -198,13 +200,13 @@ type Album = {
   year?: number;
 };
 
-type Artist = {
+export type Artist = {
   id: string;
   name: string;
   albumCount?: number;
 };
 
-type ArtistInfo = {
+export type ArtistInfo = {
   biography?: string;
   musicBrainzId?: string;
   lastFmUrl?: string;
@@ -214,7 +216,7 @@ type ArtistInfo = {
   similarArtist?: Artist[];
 };
 
-type LibraryData = {
+export type LibraryData = {
   albums: Album[];
   recentAlbums: Album[];
   recentlyPlayedAlbums: Album[];
@@ -227,14 +229,14 @@ type LibraryData = {
   };
 };
 
-type SearchResults = {
+export type SearchResults = {
   artists: Artist[];
   albums: Album[];
   songs: Song[];
   playlists: Playlist[];
 };
 
-type Song = {
+export type Song = {
   id: string;
   title: string;
   albumId?: string;
@@ -260,7 +262,7 @@ type ListeningHistoryEntry = {
   source: ListeningSource | "library";
 };
 
-type Playlist = {
+export type Playlist = {
   id: string;
   name: string;
   songCount?: number;
@@ -272,15 +274,15 @@ type Playlist = {
   changed?: string;
 };
 
-type AlbumDetail = Album & {
+export type AlbumDetail = Album & {
   song?: Song[];
 };
 
-type PlaylistDetail = Playlist & {
+export type PlaylistDetail = Playlist & {
   entry?: Song[];
 };
 
-type ArtistDetail = Artist & {
+export type ArtistDetail = Artist & {
   album?: Album[];
   info?: ArtistInfo | null;
 };
@@ -308,19 +310,19 @@ type LibraryContextMenuState =
   | { type: "playlist"; item: Playlist }
   | null;
 
-type FavoriteKind = "song" | "album" | "artist";
+export type FavoriteKind = "song" | "album" | "artist";
 type FavoriteIds = {
   songs: Set<string>;
   albums: Set<string>;
   artists: Set<string>;
 };
-type PlaylistDetailsUpdate = {
+export type PlaylistDetailsUpdate = {
   name: string;
   comment: string;
   public: boolean;
 };
 
-type LyricsPayload = {
+export type LyricsPayload = {
   lyrics?: {
     value?: string;
     synced?: boolean;
@@ -354,7 +356,7 @@ type RadioTrack = {
   timestamp?: number;
 };
 
-type RadioLikeStatus = {
+export type RadioLikeStatus = {
   enabled?: boolean;
   songId?: string | null;
   liked?: boolean;
@@ -364,7 +366,7 @@ type RadioLikeStatus = {
   error?: string;
 };
 
-type RadioStationState = {
+export type RadioStationState = {
   nowPlaying?: RadioTrack | null;
   now_playing?: RadioTrack;
   current?: RadioTrack;
@@ -394,7 +396,7 @@ type RadioSessionTurn = {
   text?: string;
 };
 
-type RadioSessionPayload = {
+export type RadioSessionPayload = {
   messages?: RadioSessionTurn[];
 };
 
@@ -403,7 +405,7 @@ type RadioStationLocale = "en-GB" | "en-US";
 type RadioSchedulePersona = { id?: string; name?: string; tagline?: string };
 type RadioScheduleShow = { id?: string; name?: string; topic?: string; mood?: string; personaId?: string; guestPersonaIds?: string[] };
 
-type RadioSchedulePayload = {
+export type RadioSchedulePayload = {
   personas?: RadioSchedulePersona[];
   shows?: RadioScheduleShow[];
   schedule?: Record<string, Array<string | null>>;
@@ -423,7 +425,7 @@ type RadioNowPlayingResponse = {
 
 type RadioRequestStatus = "pending" | "resolved" | "failed" | "unknown";
 
-type RadioRequestResult = {
+export type RadioRequestResult = {
   success: boolean;
   pending?: boolean;
   ack?: string;
@@ -1525,6 +1527,9 @@ async function fetchRadioState(stationUrl: string): Promise<RadioStationState> {
   });
 }
 
+// Transitional compatibility helpers. New call sites use data/navidrome.ts;
+// this block will be deleted once #118's persistent catalog lands on top of it.
+/* eslint-disable @typescript-eslint/no-unused-vars */
 async function navidromeRequest<T>(
   config: NavidromeConfig,
   endpoint: string,
@@ -1814,6 +1819,7 @@ async function fetchSearchResults(config: NavidromeConfig, query: string): Promi
   };
 }
 
+/* eslint-enable @typescript-eslint/no-unused-vars */
 function formatDuration(seconds?: number) {
   if (!seconds || !Number.isFinite(seconds)) return "-:--";
   const wholeSeconds = Math.max(0, Math.floor(seconds));
@@ -1902,6 +1908,7 @@ function snapshotEquals(left: BrowserSnapshot | null, right: BrowserSnapshot | n
 }
 
 export function App() {
+  const queryClient = useQueryClient();
   const [initialPlaybackSnapshot] = useState(() => loadPlaybackSnapshot());
   const [activeView, setActiveView] = useState<View>("overview");
   const [config, setConfig] = useState<NavidromeConfig | null>(() => loadStoredConfig());
@@ -2490,6 +2497,49 @@ export function App() {
     setVolume(defaultSettings.lastVolume);
   }
 
+  // These wrappers are the migration seam for server-owned data. They make
+  // repeated navigation reuse a response while preserving the existing local
+  // playback and navigation state machine.
+  function loadLibraryData(nextConfig: NavidromeConfig) {
+    return queryClient.fetchQuery({
+      queryKey: navidromeKeys.library(nextConfig),
+      queryFn: () => navidromeClient.library(nextConfig),
+    });
+  }
+
+  function loadAlbumDetail(nextConfig: NavidromeConfig, albumId: string) {
+    return queryClient.fetchQuery({
+      queryKey: navidromeKeys.album(nextConfig, albumId),
+      queryFn: () => navidromeClient.album(nextConfig, albumId),
+    });
+  }
+
+  function loadArtistDetail(nextConfig: NavidromeConfig, artistId: string) {
+    return queryClient.fetchQuery({
+      queryKey: navidromeKeys.artist(nextConfig, artistId),
+      queryFn: () => navidromeClient.artist(nextConfig, artistId),
+    });
+  }
+
+  function loadPlaylistDetail(nextConfig: NavidromeConfig, playlistId: string) {
+    return queryClient.fetchQuery({
+      queryKey: navidromeKeys.playlist(nextConfig, playlistId),
+      queryFn: () => navidromeClient.playlist(nextConfig, playlistId),
+    });
+  }
+
+  function loadSearchResults(nextConfig: NavidromeConfig, query: string) {
+    return queryClient.fetchQuery({
+      queryKey: navidromeKeys.search(nextConfig, query),
+      queryFn: () => navidromeClient.search(nextConfig, query),
+      staleTime: 15_000,
+    });
+  }
+
+  async function invalidateNavidromeData(nextConfig: NavidromeConfig) {
+    await queryClient.invalidateQueries({ queryKey: navidromeKeys.root(nextConfig) });
+  }
+
   async function refreshLibrary(nextConfig = config) {
     if (!nextConfig || libraryRefreshInFlightRef.current) return false;
 
@@ -2501,11 +2551,11 @@ export function App() {
     setStatusMessage("Checking Navidrome and loading library...");
 
     try {
-      const resolvedConfig = await resolveNavidromeConfig(nextConfig);
+      const resolvedConfig = await navidromeClient.resolveConfig(nextConfig);
       const [scanStatus, nextLibrary, nextListenerName] = await Promise.all([
-        fetchNavidromeScanStatus(resolvedConfig).catch(() => null),
-        fetchLibrary(resolvedConfig),
-        fetchNavidromeProfileName(resolvedConfig).catch(() => ""),
+        navidromeClient.scanStatus(resolvedConfig).catch(() => null),
+        loadLibraryData(resolvedConfig),
+        navidromeClient.profileName(resolvedConfig).catch(() => ""),
       ]);
       if (refreshGeneration !== libraryRefreshGenerationRef.current) return false;
       await storeNativePassword(resolvedConfig.password);
@@ -2568,7 +2618,7 @@ export function App() {
     setActiveView("albums");
 
     try {
-      const albumDetail = await fetchAlbumDetail(config, albumId);
+      const albumDetail = await loadAlbumDetail(config, albumId);
       setBackStack((currentStack) => [...currentStack, origin].slice(-40));
       setForwardStack([]);
       setDetailSelection({ type: "album", data: albumDetail });
@@ -2593,7 +2643,7 @@ export function App() {
     setActiveView("artists");
 
     try {
-      const artistDetail = await fetchArtistDetail(config, artistId);
+      const artistDetail = await loadArtistDetail(config, artistId);
       setBackStack((currentStack) => [...currentStack, origin].slice(-40));
       setForwardStack([]);
       setDetailSelection({ type: "artist", data: artistDetail });
@@ -2618,7 +2668,7 @@ export function App() {
     setActiveView("playlists");
 
     try {
-      const playlistDetail = await fetchPlaylistDetail(config, playlistId);
+      const playlistDetail = await loadPlaylistDetail(config, playlistId);
       setBackStack((currentStack) => [...currentStack, origin].slice(-40));
       setForwardStack([]);
       setDetailSelection({ type: "playlist", data: playlistDetail });
@@ -2645,7 +2695,7 @@ export function App() {
     if (!config) return;
 
     try {
-      const albumDetail = await fetchAlbumDetail(config, album.id);
+      const albumDetail = await loadAlbumDetail(config, album.id);
       replaceQueue(sortAlbumSongs(albumDetail.song ?? []));
     } catch (error) {
       setDetailStatus("error");
@@ -2657,9 +2707,9 @@ export function App() {
     if (!config) return;
 
     try {
-      const artistDetail = "album" in artist ? artist : await fetchArtistDetail(config, artist.id);
+      const artistDetail = "album" in artist ? artist : await loadArtistDetail(config, artist.id);
       const albums = artistDetail.album ?? [];
-      const albumDetails = await Promise.all(albums.slice(0, 50).map((album) => fetchAlbumDetail(config, album.id)));
+      const albumDetails = await Promise.all(albums.slice(0, 50).map((album) => loadAlbumDetail(config, album.id)));
       replaceQueue(albumDetails.flatMap((album) => album.song ?? []));
     } catch (error) {
       setDetailStatus("error");
@@ -2671,7 +2721,7 @@ export function App() {
     if (!config) return;
 
     try {
-      const playlistDetail = await fetchPlaylistDetail(config, playlist.id);
+      const playlistDetail = await loadPlaylistDetail(config, playlist.id);
       replaceQueue(playlistDetail.entry ?? [], 0, playlist);
     } catch (error) {
       setDetailStatus("error");
@@ -2696,20 +2746,22 @@ export function App() {
     setPlaylistCreateMessage("Creating playlist...");
 
     try {
-      await createPlaylist(config, trimmedName, seedSongs);
-      let nextLibrary = await fetchLibrary(config);
+      await navidromeClient.createPlaylist(config, trimmedName, seedSongs);
+      await invalidateNavidromeData(config);
+      let nextLibrary = await loadLibraryData(config);
 
       let createdPlaylist = [...nextLibrary.playlists]
         .filter((playlist) => playlist.name === trimmedName)
         .sort((a, b) => (b.changed ?? b.created ?? "").localeCompare(a.changed ?? a.created ?? ""))[0];
 
       if (createdPlaylist && (trimmedDescription || playlistPublic)) {
-        await updatePlaylistDetails(config, createdPlaylist.id, {
+        await navidromeClient.updatePlaylist(config, createdPlaylist.id, {
           name: trimmedName,
           comment: trimmedDescription,
           public: playlistPublic,
         });
-        nextLibrary = await fetchLibrary(config);
+        await invalidateNavidromeData(config);
+        nextLibrary = await loadLibraryData(config);
         createdPlaylist =
           nextLibrary.playlists.find((playlist) => playlist.id === createdPlaylist?.id) ??
           [...nextLibrary.playlists]
@@ -2740,10 +2792,11 @@ export function App() {
   async function savePlaylistDetails(playlist: Playlist, details: PlaylistDetailsUpdate) {
     if (!config) return;
 
-    await updatePlaylistDetails(config, playlist.id, details);
+    await navidromeClient.updatePlaylist(config, playlist.id, details);
+    await invalidateNavidromeData(config);
     const [nextLibrary, updatedPlaylist] = await Promise.all([
-      fetchLibrary(config),
-      fetchPlaylistDetail(config, playlist.id),
+      loadLibraryData(config),
+      loadPlaylistDetail(config, playlist.id),
     ]);
 
     setLibraryData(nextLibrary);
@@ -2753,8 +2806,9 @@ export function App() {
   async function deletePlaylistAndReturn(playlist: Playlist) {
     if (!config) return;
 
-    await deletePlaylist(config, playlist.id);
-    const nextLibrary = await fetchLibrary(config);
+    await navidromeClient.deletePlaylist(config, playlist.id);
+    await invalidateNavidromeData(config);
+    const nextLibrary = await loadLibraryData(config);
     setLibraryData(nextLibrary);
     setDetailSelection(null);
     selectView("playlists");
@@ -2780,10 +2834,11 @@ export function App() {
   async function removeSongFromPlaylistAndRefresh(playlist: PlaylistDetail, index: number) {
     if (!config) return;
 
-    await removePlaylistSong(config, playlist.id, index);
+    await navidromeClient.removePlaylistSong(config, playlist.id, index);
+    await invalidateNavidromeData(config);
     const [nextLibrary, updatedPlaylist] = await Promise.all([
-      fetchLibrary(config),
-      fetchPlaylistDetail(config, playlist.id),
+      loadLibraryData(config),
+      loadPlaylistDetail(config, playlist.id),
     ]);
     setLibraryData(nextLibrary);
     setDetailSelection({ type: "playlist", data: updatedPlaylist });
@@ -2792,10 +2847,11 @@ export function App() {
   async function reorderPlaylistAndRefresh(playlist: PlaylistDetail, songs: Song[]) {
     if (!config) return;
 
-    await replacePlaylistSongs(config, playlist, songs);
+    await navidromeClient.replacePlaylistSongs(config, playlist, songs);
+    await invalidateNavidromeData(config);
     const [nextLibrary, updatedPlaylist] = await Promise.all([
-      fetchLibrary(config),
-      fetchPlaylistDetail(config, playlist.id),
+      loadLibraryData(config),
+      loadPlaylistDetail(config, playlist.id),
     ]);
     setLibraryData(nextLibrary);
     setDetailSelection({ type: "playlist", data: updatedPlaylist });
@@ -2808,11 +2864,12 @@ export function App() {
     setPlaylistAddMessage(`Adding ${songs.length === 1 ? "song" : `${songs.length} songs`} to ${playlist.name}...`);
 
     try {
-      await addSongsToPlaylist(config, playlist.id, songs);
+      await navidromeClient.addPlaylistSongs(config, playlist.id, songs);
+      await invalidateNavidromeData(config);
       const [nextLibrary, updatedPlaylist] = await Promise.all([
-        fetchLibrary(config),
+        loadLibraryData(config),
         detailSelection?.type === "playlist" && detailSelection.data.id === playlist.id
-          ? fetchPlaylistDetail(config, playlist.id).catch(() => null)
+          ? loadPlaylistDetail(config, playlist.id).catch(() => null)
           : Promise.resolve(null),
       ]);
 
@@ -2834,7 +2891,7 @@ export function App() {
     if (!config) return;
 
     try {
-      const detail = await fetchAlbumDetail(config, album.id);
+      const detail = await loadAlbumDetail(config, album.id);
       await addSongsToSelectedPlaylist(playlist, sortAlbumSongs(detail.song ?? []));
     } catch (error) {
       setPlaylistAddStatus("error");
@@ -2846,9 +2903,9 @@ export function App() {
     if (!config) return;
 
     try {
-      const detail = await fetchArtistDetail(config, artist.id);
+      const detail = await loadArtistDetail(config, artist.id);
       const albums = detail.album ?? [];
-      const albumDetails = await Promise.all(albums.slice(0, 50).map((album) => fetchAlbumDetail(config, album.id)));
+      const albumDetails = await Promise.all(albums.slice(0, 50).map((album) => loadAlbumDetail(config, album.id)));
       await addSongsToSelectedPlaylist(playlist, albumDetails.flatMap((album) => album.song ?? []));
     } catch (error) {
       setPlaylistAddStatus("error");
@@ -2863,8 +2920,9 @@ export function App() {
     setFavoriteBusyKey(busyKey);
 
     try {
-      await setNavidromeFavorite(config, kind, id, favorite);
-      const nextLibrary = await fetchLibrary(config);
+      await navidromeClient.setFavorite(config, kind, id, favorite);
+      await invalidateNavidromeData(config);
+      const nextLibrary = await loadLibraryData(config);
       setLibraryData(nextLibrary);
       setSongContextMenu(null);
     } catch (error) {
@@ -3622,7 +3680,7 @@ export function App() {
     setLyricsLines([]);
     setLyricsMessage("");
 
-    void fetchLyrics(config, currentTrack)
+    void navidromeClient.lyrics(config, currentTrack).then(normalizeLyrics)
       .then((lines) => {
         if (cancelled) return;
         setLyricsLines(lines);
@@ -3950,8 +4008,11 @@ export function App() {
     if (position < listenThreshold || scrobbledPlayRef.current === playKey) return;
 
     scrobbledPlayRef.current = playKey;
-    void scrobbleSong(config, currentTrack)
-      .then(() => fetchLibrary(config))
+    void navidromeClient.scrobble(config, currentTrack)
+      .then(async () => {
+        await invalidateNavidromeData(config);
+        return loadLibraryData(config);
+      })
       .then((nextLibrary) => setLibraryData(nextLibrary))
       .catch(() => {
         scrobbledPlayRef.current = "";
@@ -4160,7 +4221,7 @@ export function App() {
     setSearchStatus("searching");
 
     const timeout = window.setTimeout(() => {
-      void fetchSearchResults(config, trimmedQuery)
+      void loadSearchResults(config, trimmedQuery)
         .then((results) => {
           setSearchResults(results);
           setSearchStatus("idle");
@@ -4987,12 +5048,12 @@ export function App() {
           onAddArtist={(playlist, artist) => void addArtistToPlaylist(playlist, artist)}
           onCreateAlbumPlaylist={(album) => {
             if (!config) return;
-            void fetchAlbumDetail(config, album.id).then((detail) => createPlaylistFromSongs(album.name, sortAlbumSongs(detail.song ?? [])));
+            void loadAlbumDetail(config, album.id).then((detail) => createPlaylistFromSongs(album.name, sortAlbumSongs(detail.song ?? [])));
           }}
           onCreateArtistPlaylist={(artist) => {
             if (!config) return;
-            void fetchArtistDetail(config, artist.id)
-              .then((detail) => Promise.all((detail.album ?? []).slice(0, 50).map((album) => fetchAlbumDetail(config, album.id))))
+            void loadArtistDetail(config, artist.id)
+              .then((detail) => Promise.all((detail.album ?? []).slice(0, 50).map((album) => loadAlbumDetail(config, album.id))))
               .then((albums) => createPlaylistFromSongs(artist.name, albums.flatMap((album) => album.song ?? [])));
           }}
         />

--- a/src/data/navidrome.ts
+++ b/src/data/navidrome.ts
@@ -1,0 +1,133 @@
+import type {
+  Album,
+  AlbumDetail,
+  Artist,
+  ArtistDetail,
+  ArtistInfo,
+  FavoriteKind,
+  LibraryData,
+  LyricsPayload,
+  NavidromeConfig,
+  Playlist,
+  PlaylistDetail,
+  PlaylistDetailsUpdate,
+  SearchResults,
+  Song,
+} from "../App";
+
+const API_VERSION = "1.16.1";
+const CLIENT_ID = "PrismPlayer";
+
+function normalizeServerUrl(value: string) {
+  return value.trim().replace(/\/$/, "");
+}
+
+function hasUrlScheme(value: string) {
+  return /^[a-z][a-z\d+.-]*:\/\//i.test(value);
+}
+
+function buildUrl(config: NavidromeConfig, endpoint: string, params: Record<string, string | string[]> = {}) {
+  const url = new URL(`${normalizeServerUrl(config.serverUrl)}/rest/${endpoint}.view`);
+  url.searchParams.set("u", config.username);
+  url.searchParams.set("p", config.password);
+  url.searchParams.set("v", API_VERSION);
+  url.searchParams.set("c", CLIENT_ID);
+  url.searchParams.set("f", "json");
+  Object.entries(params).forEach(([key, value]) => Array.isArray(value)
+    ? value.forEach((item) => url.searchParams.append(key, item))
+    : url.searchParams.set(key, value));
+  return url;
+}
+
+async function request<T>(config: NavidromeConfig, endpoint: string, params: Record<string, string | string[]> = {}): Promise<T> {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), 10_000);
+  try {
+    const response = await fetch(buildUrl(config, endpoint, params), { signal: controller.signal });
+    if (!response.ok) throw new Error(`Server returned HTTP ${response.status}.`);
+    const body = await response.json() as Record<string, unknown>;
+    const subsonic = body["subsonic-response"] as { status?: string; error?: { message?: string } } | undefined;
+    if (!subsonic) throw new Error("Response was not a Subsonic API payload.");
+    if (subsonic.status === "failed") throw new Error(subsonic.error?.message ?? "Navidrome rejected the request.");
+    return subsonic as T;
+  } finally {
+    window.clearTimeout(timeout);
+  }
+}
+
+async function fetchAlbums(config: NavidromeConfig): Promise<Album[]> {
+  const albums: Album[] = [];
+  for (let offset = 0; offset < 5_000; offset += 500) {
+    const response = await request<{ albumList2?: { album?: Album[] } }>(config, "getAlbumList2", { type: "alphabeticalByName", size: "500", offset: String(offset) });
+    const page = response.albumList2?.album ?? [];
+    albums.push(...page);
+    if (page.length < 500) break;
+  }
+  return albums;
+}
+
+export const navidromeKeys = {
+  root: (config: NavidromeConfig) => ["navidrome", config.serverUrl, config.username] as const,
+  library: (config: NavidromeConfig) => [...navidromeKeys.root(config), "library"] as const,
+  album: (config: NavidromeConfig, id: string) => [...navidromeKeys.root(config), "album", id] as const,
+  artist: (config: NavidromeConfig, id: string) => [...navidromeKeys.root(config), "artist", id] as const,
+  playlist: (config: NavidromeConfig, id: string) => [...navidromeKeys.root(config), "playlist", id] as const,
+  search: (config: NavidromeConfig, query: string) => [...navidromeKeys.root(config), "search", query] as const,
+};
+
+export const navidromeClient = {
+  buildCoverArtUrl(config: NavidromeConfig, coverArt?: string, size = "420") {
+    return coverArt ? buildUrl(config, "getCoverArt", { id: coverArt, size }).toString() : null;
+  },
+  buildStreamUrl(config: NavidromeConfig, songId: string) {
+    return buildUrl(config, "stream", { id: songId }).toString();
+  },
+  async resolveConfig(config: NavidromeConfig) {
+    const normalized = normalizeServerUrl(config.serverUrl);
+    const candidates = !normalized || hasUrlScheme(normalized) ? (normalized ? [normalized] : []) : [`https://${normalized}`, `http://${normalized}`];
+    let lastError: unknown = null;
+    for (const serverUrl of candidates) {
+      try { await request({ ...config, serverUrl }, "ping"); return { ...config, serverUrl }; } catch (error) { lastError = error; }
+    }
+    throw lastError instanceof Error ? lastError : new Error("Could not reach Navidrome.");
+  },
+  async profileName(config: NavidromeConfig) {
+    const response = await fetch(`${normalizeServerUrl(config.serverUrl)}/auth/login`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ username: config.username, password: config.password }) });
+    if (!response.ok) throw new Error(`Server returned HTTP ${response.status}.`);
+    return ((await response.json()) as { name?: string }).name?.trim() ?? "";
+  },
+  async scanStatus(config: NavidromeConfig) {
+    return (await request<{ scanStatus?: { scanning?: boolean; lastScan?: string | number } }>(config, "getScanStatus")).scanStatus ?? null;
+  },
+  async library(config: NavidromeConfig): Promise<LibraryData> {
+    const [albums, newest, recent, artists, playlists, starred] = await Promise.all([
+      fetchAlbums(config),
+      request<{ albumList2?: { album?: Album[] } }>(config, "getAlbumList2", { type: "newest", size: "60" }),
+      request<{ albumList2?: { album?: Album[] } }>(config, "getAlbumList2", { type: "recent", size: "60" }),
+      request<{ artists?: { index?: Array<{ artist?: Artist[] }> } }>(config, "getArtists"),
+      request<{ playlists?: { playlist?: Playlist[] } }>(config, "getPlaylists").catch(() => null),
+      request<{ starred2?: { artist?: Artist[]; album?: Album[]; song?: Song[] } }>(config, "getStarred2").catch(() => null),
+    ]);
+    return { albums, recentAlbums: newest.albumList2?.album ?? [], recentlyPlayedAlbums: recent.albumList2?.album ?? [], artists: artists.artists?.index?.flatMap((index) => index.artist ?? []) ?? [], playlists: playlists?.playlists?.playlist ?? [], favorites: { artists: starred?.starred2?.artist ?? [], albums: starred?.starred2?.album ?? [], songs: starred?.starred2?.song ?? [] } };
+  },
+  async album(config: NavidromeConfig, id: string) { return (await request<{ album: AlbumDetail }>(config, "getAlbum", { id })).album; },
+  async artist(config: NavidromeConfig, id: string): Promise<ArtistDetail> {
+    const [artist, info] = await Promise.all([request<{ artist: ArtistDetail }>(config, "getArtist", { id }), request<{ artistInfo2?: ArtistInfo }>(config, "getArtistInfo2", { id }).catch(() => null)]);
+    return { ...artist.artist, info: info?.artistInfo2 ?? null };
+  },
+  async playlist(config: NavidromeConfig, id: string) { return (await request<{ playlist: PlaylistDetail }>(config, "getPlaylist", { id })).playlist; },
+  async lyrics(config: NavidromeConfig, song: Song) { return request<LyricsPayload>(config, "getLyrics", { artist: song.artist ?? "", title: song.title }); },
+  async search(config: NavidromeConfig, query: string): Promise<SearchResults> {
+    const [results, playlists] = await Promise.all([request<{ searchResult3?: { artist?: Artist[]; album?: Album[]; song?: Song[] } }>(config, "search3", { query, artistCount: "12", albumCount: "18", songCount: "40" }), request<{ playlists?: { playlist?: Playlist[] } }>(config, "getPlaylists").catch(() => null)]);
+    const normalized = query.toLocaleLowerCase();
+    return { artists: results.searchResult3?.artist ?? [], albums: results.searchResult3?.album ?? [], songs: results.searchResult3?.song ?? [], playlists: playlists?.playlists?.playlist?.filter((playlist) => playlist.name.toLocaleLowerCase().includes(normalized)).slice(0, 20) ?? [] };
+  },
+  createPlaylist: (config: NavidromeConfig, name: string, songs: Song[] = []) => request(config, "createPlaylist", { name, songId: songs.map((song) => song.id) }),
+  updatePlaylist: (config: NavidromeConfig, id: string, details: PlaylistDetailsUpdate) => request(config, "updatePlaylist", { playlistId: id, name: details.name, comment: details.comment, public: String(details.public) }),
+  deletePlaylist: (config: NavidromeConfig, id: string) => request(config, "deletePlaylist", { id }),
+  removePlaylistSong: (config: NavidromeConfig, id: string, index: number) => request(config, "updatePlaylist", { playlistId: id, songIndexToRemove: String(index) }),
+  replacePlaylistSongs: (config: NavidromeConfig, playlist: PlaylistDetail, songs: Song[]) => request(config, "updatePlaylist", { playlistId: playlist.id, name: playlist.name, comment: playlist.comment ?? "", public: String(Boolean(playlist.public)), songIndexToRemove: (playlist.entry ?? []).map((_, index, entries) => String(entries.length - index - 1)), songIdToAdd: songs.map((song) => song.id) }),
+  addPlaylistSongs: (config: NavidromeConfig, id: string, songs: Song[]) => request(config, "updatePlaylist", { playlistId: id, songIdToAdd: songs.map((song) => song.id) }),
+  setFavorite: (config: NavidromeConfig, kind: FavoriteKind, id: string, favorite: boolean) => request(config, favorite ? "star" : "unstar", kind === "song" ? { id } : kind === "album" ? { albumId: id } : { artistId: id }),
+  scrobble: (config: NavidromeConfig, song: Song) => request(config, "scrobble", { id: song.id, time: String(Date.now()), submission: "true" }),
+};

--- a/src/data/queryClient.ts
+++ b/src/data/queryClient.ts
@@ -1,0 +1,15 @@
+import { QueryClient } from "@tanstack/react-query";
+
+// Server responses are deliberately kept separate from playback, radio timing,
+// and UI preference state. Those values remain owned by Prism's existing React
+// state because they change locally and are not cacheable API resources.
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      gcTime: 10 * 60_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});

--- a/src/data/subwave.ts
+++ b/src/data/subwave.ts
@@ -1,0 +1,30 @@
+import type { RadioLikeStatus, RadioRequestResult, RadioSchedulePayload, RadioSessionPayload, RadioStationState } from "../App";
+
+function stationOrigin(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error("Enter a valid Subwave station URL.");
+  return new URL(/^[a-z][a-z\d+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`).origin;
+}
+
+async function request<T>(stationUrl: string, endpoint: string, init?: RequestInit): Promise<T> {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), 8_000);
+  try {
+    const response = await fetch(`${stationOrigin(stationUrl)}/api/${endpoint.replace(/^\/+/, "")}`, { cache: "no-store", ...init, signal: controller.signal });
+    if (!response.ok) throw new Error("That address answered, but not like a Subwave station.");
+    return (await response.json()) as T;
+  } finally {
+    window.clearTimeout(timeout);
+  }
+}
+
+// Radio transport alignment and playback promotion are local timing concerns;
+// this client owns requests but deliberately does not introduce a Query cache.
+export const subwaveClient = {
+  state: (stationUrl: string) => request<RadioStationState>(stationUrl, "state"),
+  session: (stationUrl: string) => request<RadioSessionPayload>(stationUrl, "session"),
+  schedule: (stationUrl: string) => request<RadioSchedulePayload>(stationUrl, "schedule"),
+  likeStatus: (stationUrl: string) => request<RadioLikeStatus>(stationUrl, "like"),
+  submitLike: (stationUrl: string, songId: string) => request<RadioLikeStatus>(stationUrl, "like", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ songId }) }),
+  submitRequest: (stationUrl: string, text: string, name: string) => request<RadioRequestResult>(stationUrl, "request", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ text, name }) }),
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { App } from "./App";
+import { queryClient } from "./data/queryClient";
 import "./styles.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Outcome

Moves Navidrome's server-owned reads behind typed clients and a TanStack Query cache so repeat album, artist, playlist, library, and search navigation can reuse request results. Playback, radio timing/alignment, and UI preferences remain Prism-local state.

## Changes

- Add a shared TanStack Query client and provider.
- Extract typed Navidrome request, detail, search, library, and mutation operations into `src/data/navidrome.ts`.
- Add stable query keys that identify a server by URL and username without including the password.
- Route library, detail, search, playlist, favorite, and scrobble flows through the cache; invalidate Navidrome keys after mutations.
- Add a typed Subwave request client without caching radio transport state, because listener alignment and playback promotion are timing-sensitive local behavior.

## Relationship to #118

#118 will persist the catalog snapshot in IndexedDB and hydrate it at launch. This PR deliberately stops at in-memory Query caching and typed server boundaries, so #118 can add persistence without coupling playback state or credentials to the query cache.

## Validation

- `npm run test`
- `npm run build`
- `git diff --check`

## Rollback

Revert this PR to return to the existing direct request flow. No server migration or persisted-data migration is included.
