### PR TITLE
fix: Keep Prism playback and playlist menus stable

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,7 +41,6 @@ fn clear_navidrome_password() -> Result<(), String> {
 struct DiscordPresence {
     title: String,
     artist: String,
-    album: Option<String>,
     station: Option<String>,
     playing: bool,
     started_at: Option<i64>,
@@ -98,21 +97,13 @@ fn publish_discord_presence(app: &tauri::AppHandle, presence: DiscordPresence) -
 
 fn build_discord_activity(presence: DiscordPresence) -> activity::Activity<'static> {
     let station = presence.station.filter(|station| !station.trim().is_empty());
-    let is_radio = station.is_some();
     let state = if let Some(station) = station {
         format!("{} · Live on {station}", presence.artist)
     } else {
-        presence
-            .album
-            .filter(|album| !album.trim().is_empty())
-            .map_or_else(|| presence.artist.clone(), |album| format!("{} · {album}", presence.artist))
+        presence.artist.clone()
     };
     let title = presence.title;
-    let track_details = if is_radio {
-        format!("{title} · {}", presence.artist)
-    } else {
-        title.clone()
-    };
+    let track_details = title.clone();
     let details = if presence.playing {
         track_details
     } else {
@@ -120,11 +111,7 @@ fn build_discord_activity(presence: DiscordPresence) -> activity::Activity<'stat
     };
     let mut activity = activity::Activity::new()
         .activity_type(activity::ActivityType::Listening)
-        .status_display_type(if is_radio {
-            activity::StatusDisplayType::Details
-        } else {
-            activity::StatusDisplayType::State
-        })
+        .status_display_type(activity::StatusDisplayType::Details)
         .details(details)
         .state(state)
         .buttons(vec![

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2009,6 +2009,7 @@ export function App() {
   const [playlistSeedSongs, setPlaylistSeedSongs] = useState<Song[] | null>(null);
   const [playlistCreateStatus, setPlaylistCreateStatus] = useState<"idle" | "saving" | "error">("idle");
   const [playlistCreateMessage, setPlaylistCreateMessage] = useState("");
+  const [sidebarPlaylistMenuOpen, setSidebarPlaylistMenuOpen] = useState(false);
   const [songContextMenu, setSongContextMenu] = useState<SongContextMenuState>(null);
   const [libraryContextMenu, setLibraryContextMenu] = useState<LibraryContextMenuState>(null);
   const [playlistDeleteTarget, setPlaylistDeleteTarget] = useState<Playlist | null>(null);
@@ -3580,7 +3581,6 @@ export function App() {
       presence: {
         title: track.title ?? "Live radio",
         artist: track.artist ?? (radioPresence ? "Subwave" : "Unknown artist"),
-        album: track.album ?? null,
         station: radioPresence ? radioStationName(radioStationState, radioStationUrl, appSettings.radioStationNames[radioStationUrl]) : null,
         playing: radioPresence ? true : isPlaying,
         startedAt: radioPresence || !isPlaying ? null : Date.now() - Math.round(position * 1000),
@@ -3686,7 +3686,7 @@ export function App() {
     if (config) {
       void refreshLibrary(config);
     }
-  }, [config]);
+  }, [config?.serverUrl, config?.username, config?.password]);
 
   useEffect(() => {
     if (!config) return;
@@ -4437,7 +4437,11 @@ export function App() {
             <Music2 size={18} />
             Songs
           </button>
-          <DropdownMenu.Root modal={false}>
+          <DropdownMenu.Root
+            modal={false}
+            open={sidebarPlaylistMenuOpen || libraryContextMenu?.type === "playlist"}
+            onOpenChange={setSidebarPlaylistMenuOpen}
+          >
             <DropdownMenu.Trigger asChild>
               <button
                 className={`nav-item nav-child nav-parent nav-playlist-trigger ${activeView === "playlists" ? "active" : ""}`}


### PR DESCRIPTION
## Outcome

Stops the repeated Navidrome refresh loop that makes the Home greeting visibly flicker, preserves the Playlists flyout while a playlist's context menu is open, and makes Discord lead its activity preview with the track title followed by the artist.

## Changes

- Refresh a saved Navidrome connection only when its actual connection fields change, rather than whenever the resolved config object is replaced.
- Control the Playlists flyout so it remains open while its playlist context menu is active.
- Use Discord activity details for the track title and activity state for the artist, without showing the album in place of the song title.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- Restarted the feature preview at `http://10.10.10.11:1420/` and verified an HTTP 200 response from this branch.

## Rollback

Revert commit `b85419f` to restore the previous behavior.
