### PR TITLE
fix: Keep playlist context actions open on hover

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3046,6 +3046,21 @@ export function App() {
     }
   }
 
+  function handleSidebarPlaylistMenuOpenChange(open: boolean) {
+    // A playlist's right-click menu is rendered in its own Radix portal. Keep
+    // the sidebar flyout open while that related menu owns focus, rather than
+    // treating the portal boundary as an outside interaction.
+    if (!open && libraryContextMenu?.type === "playlist") return;
+    setSidebarPlaylistMenuOpen(open);
+  }
+
+  function keepSidebarPlaylistMenuOpenForPlaylistContext(event: Event) {
+    const target = event.target;
+    if (target instanceof HTMLElement && target.closest(".library-context-menu")) {
+      event.preventDefault();
+    }
+  }
+
   function clearDetail() {
     setDetailSelection(null);
     setDetailStatus("idle");
@@ -4440,7 +4455,7 @@ export function App() {
           <DropdownMenu.Root
             modal={false}
             open={sidebarPlaylistMenuOpen || libraryContextMenu?.type === "playlist"}
-            onOpenChange={setSidebarPlaylistMenuOpen}
+            onOpenChange={handleSidebarPlaylistMenuOpenChange}
           >
             <DropdownMenu.Trigger asChild>
               <button
@@ -4461,6 +4476,8 @@ export function App() {
                 sideOffset={10}
                 collisionPadding={12}
                 aria-label="Playlists"
+                onFocusOutside={keepSidebarPlaylistMenuOpenForPlaylistContext}
+                onInteractOutside={keepSidebarPlaylistMenuOpenForPlaylistContext}
               >
                 <DropdownMenu.Item asChild>
                   <button className="sidebar-playlist-menu-all" type="button" onClick={() => selectView("playlists")}>


### PR DESCRIPTION
## Outcome

Keeps the Playlists flyout and a playlist's contextual right-click menu open together, including when the pointer moves into the contextual menu.

## Changes

- Preserve the sidebar Playlists flyout while a playlist context menu owns focus.
- Treat the related context-menu portal as part of the same interaction instead of an outside-focus dismissal.

## Validation

- `npm test`
- `npm run build`
- Restarted the feature preview at `http://10.10.10.11:1420/` from this branch.

## Rollback

Revert this single commit to restore the prior flyout behavior.
