### PR TITLE
fix: Keep active radio playback connected when opening Radio

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4707,7 +4707,7 @@ export function App() {
               tuneInRadio={tuneInRadio}
               onStartRadio={() => {
                 selectView("radio");
-                void tuneInRadio();
+                if (radioStatus !== "playing") void tuneInRadio();
               }}
               onAddFirstRadioStation={tuneInRadio}
               albums={libraryData.albums}


### PR DESCRIPTION
## Outcome

Opening Radio from the Home card now preserves an already-playing Subwave stream.

## Changes

- Navigate directly to Radio when the radio session is playing.
- Continue to tune in when radio is not already playing.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`

## Rollback

Revert commit `cbcb46e` to restore the previous tune-on-open behavior.
