### PR TITLE
feat: Add a mute toggle to volume controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ import {
   MessageCircle,
   UserRound,
   Volume2,
+  VolumeX,
   Waves,
   X,
 } from "lucide-react";
@@ -1998,6 +1999,7 @@ export function App() {
   const [radioStatus, setRadioStatus] = useState<RadioStatus>("idle");
   const [radioMessage, setRadioMessage] = useState(appSettings.radioStationUrl ? "Ready to tune in." : "Add a Subwave station URL to start.");
   const [radioVolume, setRadioVolume] = useState(appSettings.lastVolume);
+  const [isMuted, setIsMuted] = useState(false);
   const [radioClockNow, setRadioClockNow] = useState(() => Date.now());
   const [radioWaveformBars, setRadioWaveformBars] = useState<number[]>(idleRadioWaveformBars);
   const [radioPopover, setRadioPopover] = useState<"schedule" | "request" | "booth" | null>(null);
@@ -3581,6 +3583,10 @@ export function App() {
     updateAppSettings({ ...appSettings, lastVolume: clampedVolume });
   }
 
+  function toggleMuted() {
+    setIsMuted((muted) => !muted);
+  }
+
   async function resetConnection() {
     try {
       await clearNativePassword();
@@ -3891,6 +3897,11 @@ export function App() {
     if (!audio) return;
     audio.volume = volume;
   }, [volume]);
+
+  useEffect(() => {
+    if (audioRef.current) audioRef.current.muted = isMuted;
+    if (radioAudioRef.current) radioAudioRef.current.muted = isMuted;
+  }, [isMuted]);
 
   useEffect(() => {
     setRadioStationInput(appSettings.radioStationUrl);
@@ -5073,8 +5084,10 @@ export function App() {
         </div>
 
         <div className="player-actions">
-          <div className="volume-control">
-            <Volume2 size={16} />
+          <div className={`volume-control ${isMuted ? "muted" : ""}`}>
+            <button className="volume-mute-button" type="button" onClick={toggleMuted} aria-label={isMuted ? "Unmute volume" : "Mute volume"} aria-pressed={isMuted}>
+              {isMuted ? <VolumeX size={16} /> : <Volume2 size={16} />}
+            </button>
             <input
               className="volume-slider"
               type="range"
@@ -5083,7 +5096,8 @@ export function App() {
               step="0.01"
               value={isRadioPlaying ? radioVolume : volume}
               onChange={(event) => (isRadioPlaying ? setRadioPlaybackVolume(Number(event.target.value)) : setPlayerVolume(Number(event.target.value)))}
-              aria-label="Volume"
+              disabled={isMuted}
+              aria-label={isMuted ? "Volume muted" : "Volume"}
             />
           </div>
         </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -4801,7 +4801,13 @@ button.similar-chip:hover,
   width: 24px;
   height: 24px;
   padding: 0;
+  border-radius: 999px;
+  background: transparent;
   cursor: pointer;
+}
+
+.volume-mute-button:hover {
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .volume-control.muted {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4789,10 +4789,28 @@ button.similar-chip:hover,
 
 .volume-control {
   display: grid;
-  grid-template-columns: 16px 132px;
+  grid-template-columns: 24px 132px;
   align-items: center;
   gap: 8px;
   color: rgba(244, 241, 236, 0.58);
+}
+
+.volume-mute-button {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  cursor: pointer;
+}
+
+.volume-control.muted {
+  color: rgba(244, 241, 236, 0.32);
+}
+
+.volume-control .volume-slider:disabled {
+  cursor: default;
+  opacity: 0.36;
 }
 
 .player-panel-toggle {


### PR DESCRIPTION
## Summary

Make Prism's volume icon a mute/unmute control while preserving the existing volume slider placement.

## Changes

- Toggle mute for local and radio audio from the volume icon.
- Change the icon and accessible label to reflect the muted state.
- Disable and grey out the existing volume slider while muted without losing its selected level.

## Validation

- `npm run test`
- `npm run build`
- Preview responds from the feature worktree at `http://10.10.10.11:1425/`

## Rollback

Revert this PR to restore the non-interactive volume icon and always-enabled slider.
