### PR TITLE
feat: Add reusable what’s new release notes

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -45,6 +45,7 @@ Use Conventional Commits for commit messages and pull request titles:
    - `package.json` version bump
    - `package-lock.json` version bump
    - `src-tauri/tauri.conf.json` version bump
+   - A curated entry for the new version in `src/whatsNew.ts`, with the user-facing highlights shown after update
 8. Merge the release PR when the changelog and version look right.
 9. release-please creates the Git tag and GitHub release.
 10. The `Build` workflow runs on the published release, builds the macOS DMG and Windows NSIS installer, stores them as workflow artifacts, and uploads them to the GitHub release. The DMG is named `Prism-player-vX.Y.Z.dmg`.
@@ -65,6 +66,7 @@ Before merging a release PR, check:
 
 - Changelog entries are understandable to users.
 - Version bump matches the impact of the changes.
+- `src/whatsNew.ts` has concise, reviewed copy for the new app version.
 - The app builds locally or CI is green.
 - Any new privacy, signing, platform, or server-API behavior is documented.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import * as AlertDialog from "@radix-ui/react-alert-dialog";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import * as Dialog from "@radix-ui/react-dialog";
 import { deleteLibraryCatalog, readLibraryCatalog, writeLibraryCatalog } from "./libraryCatalog";
+import { getCurrentReleaseNotes, getUnreadReleaseNotes, type WhatsNewRelease } from "./whatsNew";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   AlertCircle,
@@ -191,6 +192,7 @@ type AppSettings = {
   analyticsPromptDismissed: boolean;
   discordPresenceEnabled: boolean;
   updateDismissedVersion: string;
+  lastSeenWhatsNewVersion: string;
   coverWashEnabled: boolean;
   colorTheme: ColorTheme;
   lowPerformanceMode: boolean;
@@ -529,6 +531,7 @@ const defaultSettings: AppSettings = {
   analyticsPromptDismissed: false,
   discordPresenceEnabled: false,
   updateDismissedVersion: "",
+  lastSeenWhatsNewVersion: "",
   coverWashEnabled: true,
   colorTheme: "prism",
   lowPerformanceMode: false,
@@ -725,6 +728,7 @@ function loadStoredSettings(): AppSettings {
       analyticsPromptDismissed: Boolean(parsed.analyticsPromptDismissed),
       discordPresenceEnabled: Boolean(parsed.discordPresenceEnabled),
       updateDismissedVersion: typeof parsed.updateDismissedVersion === "string" ? parsed.updateDismissedVersion : "",
+      lastSeenWhatsNewVersion: typeof parsed.lastSeenWhatsNewVersion === "string" ? parsed.lastSeenWhatsNewVersion : "",
       coverWashEnabled: parsed.coverWashEnabled ?? defaultSettings.coverWashEnabled,
       colorTheme: colorThemes.some((theme) => theme.id === parsed.colorTheme) ? parsed.colorTheme as ColorTheme : defaultSettings.colorTheme,
       lowPerformanceMode: Boolean(parsed.lowPerformanceMode),
@@ -1944,6 +1948,7 @@ export function App() {
   const [config, setConfig] = useState<NavidromeConfig | null>(() => loadStoredConfig());
   const [form, setForm] = useState<NavidromeConfig>(() => loadStoredConfig() ?? emptyConfig);
   const [appSettings, setAppSettings] = useState<AppSettings>(() => loadStoredSettings());
+  const [whatsNewOpen, setWhatsNewOpen] = useState(false);
   const [availableUpdate, setAvailableUpdate] = useState<AvailableUpdate | null>(null);
   const [updateCheckStatus, setUpdateCheckStatus] = useState<"idle" | "checking" | "up-to-date" | "available" | "error">("idle");
   const [status, setStatus] = useState<ConnectionStatus>("idle");
@@ -2078,6 +2083,17 @@ export function App() {
     backStack,
     forwardStack,
   };
+
+  const currentReleaseNotes = useMemo(() => getCurrentReleaseNotes(APP_VERSION), []);
+  const unreadReleaseNotes = useMemo(
+    () => getUnreadReleaseNotes(APP_VERSION, appSettings.lastSeenWhatsNewVersion),
+    [appSettings.lastSeenWhatsNewVersion],
+  );
+  const whatsNewReleases = unreadReleaseNotes.length ? unreadReleaseNotes : currentReleaseNotes ? [currentReleaseNotes] : [];
+
+  useEffect(() => {
+    if (unreadReleaseNotes.length) setWhatsNewOpen(true);
+  }, [unreadReleaseNotes]);
 
   useEffect(() => {
     window.history.replaceState({ prismSnapshot: navigationStateRef.current.snapshot } satisfies PrismHistoryState, "");
@@ -2274,6 +2290,11 @@ export function App() {
 
     setAppSettings(normalizedSettings);
     localStorage.setItem(SETTINGS_KEY, JSON.stringify(normalizedSettings));
+  }
+
+  function dismissWhatsNew() {
+    updateAppSettings({ ...appSettings, lastSeenWhatsNewVersion: APP_VERSION });
+    setWhatsNewOpen(false);
   }
 
   function saveRadioStation(origin: string, discoveredName?: string) {
@@ -4760,6 +4781,8 @@ export function App() {
               availableUpdate={availableUpdate}
               updateCheckStatus={updateCheckStatus}
               onCheckForUpdates={() => void checkForUpdates()}
+              canOpenWhatsNew={Boolean(currentReleaseNotes)}
+              onOpenWhatsNew={() => setWhatsNewOpen(true)}
               onSave={saveConnection}
               onReset={resetConnection}
             />
@@ -5157,6 +5180,9 @@ export function App() {
           onSave={saveConnection}
           onClose={() => setSetupOpen(false)}
         />
+      ) : null}
+      {whatsNewOpen && whatsNewReleases.length ? (
+        <WhatsNewDialog releases={whatsNewReleases} onClose={dismissWhatsNew} />
       ) : null}
       {playlistCreatorOpen ? (
         <PrismDialog open={playlistCreatorOpen} onOpenChange={(open) => !open && closePlaylistCreator()}>
@@ -5940,6 +5966,41 @@ function UpdateBanner({ update, onDismiss }: { update: AvailableUpdate; onDismis
   );
 }
 
+function WhatsNewDialog({ releases, onClose }: { releases: WhatsNewRelease[]; onClose: () => void }) {
+  const latestRelease = releases[0];
+
+  return (
+    <PrismDialog open onOpenChange={(open) => !open && onClose()}>
+      <section className="whats-new-modal" aria-labelledby="whats-new-title">
+        <button className="icon-button close-button" type="button" aria-label="Close what’s new" onClick={onClose}>
+          <X size={18} />
+        </button>
+        <div className="whats-new-art" aria-hidden="true">
+          <Star size={30} />
+        </div>
+        <p className="eyebrow">What’s new</p>
+        <Dialog.Title asChild><h2 id="whats-new-title">Prism {latestRelease.version}</h2></Dialog.Title>
+        <Dialog.Description asChild><p className="whats-new-copy">
+          {releases.length === 1 ? latestRelease.title : `Here’s what changed since Prism ${releases[releases.length - 1]?.version}.`}
+        </p></Dialog.Description>
+        <div className="whats-new-release-list">
+          {releases.map((release) => (
+            <section className="whats-new-release" key={release.version}>
+              {releases.length > 1 ? <h3>Prism {release.version}</h3> : null}
+              <ul>
+                {release.highlights.map((highlight) => <li key={highlight}>{highlight}</li>)}
+              </ul>
+            </section>
+          ))}
+        </div>
+        <div className="whats-new-actions">
+          <button className="connect-button" type="button" onClick={onClose}>Got it</button>
+        </div>
+      </section>
+    </PrismDialog>
+  );
+}
+
 function SettingsView({
   form,
   setForm,
@@ -5959,6 +6020,8 @@ function SettingsView({
   availableUpdate,
   updateCheckStatus,
   onCheckForUpdates,
+  canOpenWhatsNew,
+  onOpenWhatsNew,
   onSave,
   onReset,
 }: {
@@ -5980,6 +6043,8 @@ function SettingsView({
   availableUpdate: AvailableUpdate | null;
   updateCheckStatus: "idle" | "checking" | "up-to-date" | "available" | "error";
   onCheckForUpdates: () => void;
+  canOpenWhatsNew: boolean;
+  onOpenWhatsNew: () => void;
   onSave: (event?: FormEvent<HTMLFormElement>) => Promise<void>;
   onReset: () => void;
 }) {
@@ -6320,6 +6385,12 @@ function SettingsView({
           <a href={PRISM_RELEASES_URL} target="_blank" rel="noreferrer"><Download size={16} /> Releases <ExternalLink size={13} /></a>
           <a href={PRISM_DISCORD_URL} target="_blank" rel="noreferrer"><MessageCircle size={16} /> Discord <ExternalLink size={13} /></a>
         </div>
+        {canOpenWhatsNew ? <div className="form-actions about-whats-new-action">
+          <button className="secondary-button" type="button" onClick={onOpenWhatsNew}>
+            <Star size={16} />
+            What’s New
+          </button>
+        </div> : null}
       </section> : null}
 
       {activeTab === "advanced" ? <section className="settings-panel">

--- a/src/styles.css
+++ b/src/styles.css
@@ -4207,7 +4207,8 @@ button.similar-chip:hover,
 }
 
 .setup-modal,
-.playlist-modal {
+.playlist-modal,
+.whats-new-modal {
   position: fixed;
   top: 50%;
   left: 50%;
@@ -4227,6 +4228,10 @@ button.similar-chip:hover,
 
 .playlist-modal {
   width: min(680px, calc(100vw - 56px));
+}
+
+.whats-new-modal {
+  width: min(500px, calc(100vw - 56px));
 }
 
 .confirm-backdrop {
@@ -4317,6 +4322,17 @@ button.similar-chip:hover,
   color: #fff8e8;
 }
 
+.whats-new-art {
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 16px;
+  border-radius: 999px;
+  background: rgba(var(--prism-highlight-rgb), 0.18);
+  color: var(--prism-accent-strong);
+}
+
 .setup-modal h2 {
   margin-top: 6px;
   font-size: 22px;
@@ -4324,12 +4340,50 @@ button.similar-chip:hover,
   line-height: 1.08;
 }
 
+.whats-new-modal h2 {
+  margin-top: 6px;
+  font-size: 24px;
+  font-weight: 600;
+}
+
 .setup-copy,
+.whats-new-copy,
 .wizard-status {
   margin-top: 10px;
   color: rgba(244, 241, 236, 0.68);
   font-size: 13px;
   line-height: 1.45;
+}
+
+.whats-new-release-list {
+  display: grid;
+  gap: 16px;
+  margin-top: 22px;
+}
+
+.whats-new-release {
+  display: grid;
+  gap: 8px;
+}
+
+.whats-new-release h3 {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.whats-new-release ul {
+  display: grid;
+  gap: 8px;
+  padding-left: 19px;
+  color: rgba(244, 241, 236, 0.78);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.whats-new-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 24px;
 }
 
 .wizard-status.bad {
@@ -4954,7 +5008,8 @@ button.similar-chip:hover,
 
 .song-context-menu,
 .playlist-modal,
-.setup-modal {
+.setup-modal,
+.whats-new-modal {
   outline: 1px solid rgba(255, 255, 255, 0.035);
 }
 

--- a/src/whatsNew.ts
+++ b/src/whatsNew.ts
@@ -1,0 +1,39 @@
+export type WhatsNewRelease = {
+  version: string;
+  title: string;
+  highlights: string[];
+};
+
+// Add polished, user-facing release highlights here as each version is prepared.
+// Keeping this curated means the in-app experience stays concise even when the
+// full GitHub changelog includes maintenance and developer-facing changes.
+export const WHATS_NEW_RELEASES: WhatsNewRelease[] = [];
+
+function versionParts(version: string) {
+  return version.replace(/^v/, "").split(".").map((part) => Number.parseInt(part, 10) || 0);
+}
+
+export function compareVersions(left: string, right: string) {
+  const leftParts = versionParts(left);
+  const rightParts = versionParts(right);
+  const length = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+    if (difference !== 0) return difference;
+  }
+
+  return 0;
+}
+
+export function getCurrentReleaseNotes(currentVersion: string) {
+  return WHATS_NEW_RELEASES.find((release) => compareVersions(release.version, currentVersion) === 0) ?? null;
+}
+
+export function getUnreadReleaseNotes(currentVersion: string, lastSeenVersion: string) {
+  if (!lastSeenVersion) return getCurrentReleaseNotes(currentVersion) ? [getCurrentReleaseNotes(currentVersion)!] : [];
+
+  return WHATS_NEW_RELEASES
+    .filter((release) => compareVersions(release.version, lastSeenVersion) > 0 && compareVersions(release.version, currentVersion) <= 0)
+    .sort((left, right) => compareVersions(right.version, left.version));
+}


### PR DESCRIPTION
## Outcome

Adds a reusable, version-aware **What’s New** experience for Prism releases.

## What changed

- Stores the last app version whose release notes were dismissed on this device.
- Shows all curated release entries a user missed when they update across versions.
- Adds a Settings → About entry to reopen the current version’s notes.
- Keeps release copy in a dedicated, intentionally empty registry for the final release editorial pass.

## Validation

- `npm run test`
- `npm run build`
- Feature preview served successfully from the dedicated worktree.

## Rollout

Before a release is packaged, add the user-facing highlights for that release to `src/whatsNew.ts`. Until then, no modal is shown.

## Rollback

Revert this PR to remove the release-note modal and its local preference.
