### PR TITLE
fix: Report native desktop architecture to Beacon

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,6 +36,15 @@ fn clear_navidrome_password() -> Result<(), String> {
     }
 }
 
+#[tauri::command]
+fn get_native_architecture() -> &'static str {
+    match std::env::consts::ARCH {
+        "aarch64" => "arm64",
+        "x86_64" => "x64",
+        _ => "unknown",
+    }
+}
+
 #[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct DiscordPresence {
@@ -165,7 +174,8 @@ pub fn run() {
             clear_discord_presence,
             get_navidrome_password,
             set_navidrome_password,
-            clear_navidrome_password
+            clear_navidrome_password,
+            get_native_architecture
         ])
         .run(tauri::generate_context!())
         .expect("error while running Prism Player");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -759,10 +759,16 @@ function getRuntimePlatform() {
   return userAgentData?.platform || navigator.platform || "unknown";
 }
 
-function getRuntimeArch() {
-  const userAgent = navigator.userAgent.toLowerCase();
-  if (userAgent.includes("arm64") || userAgent.includes("aarch64")) return "arm64";
-  if (userAgent.includes("x86_64") || userAgent.includes("win64") || userAgent.includes("wow64")) return "x64";
+async function getRuntimeArch() {
+  if (!isTauriDesktopApp()) return "unknown";
+
+  try {
+    const architecture = await invoke<string>("get_native_architecture");
+    if (architecture === "arm64" || architecture === "x64") return architecture;
+  } catch {
+    // Analytics stays best-effort when native runtime details are unavailable.
+  }
+
   return "unknown";
 }
 
@@ -790,7 +796,7 @@ async function sendAnalyticsPing(libraryData?: LibraryData) {
       project: "prism-player",
       install_id: getInstallId(),
       version: APP_VERSION,
-      arch: getRuntimeArch(),
+      arch: await getRuntimeArch(),
       timestamp: new Date().toISOString(),
       channel: isDev ? "dev" : "release",
       os: getRuntimePlatform(),


### PR DESCRIPTION
## Outcome

Beacon analytics now records the native Tauri runtime architecture for installed Prism desktop apps.

## What changed

- Adds a minimal Tauri command that maps the native Rust architecture to `arm64`, `x64`, or `unknown`.
- Uses that command only when Prism is running inside Tauri.
- Reports `unknown` for browser previews instead of inferring architecture from the browser user agent.
- Leaves the existing operating-system label unchanged.

## Validation

- `npm run test`
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`

## Rollback

Revert this PR to return Beacon architecture reporting to the prior browser-user-agent inference.
