### PR TITLE
feat: Add Prism 1.0 release highlights

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6166,7 +6166,7 @@ function WhatsNewDialog({ releases, onClose }: { releases: WhatsNewRelease[]; on
           <Star size={30} />
         </div>
         <p className="eyebrow">What’s new</p>
-        <Dialog.Title asChild><h2 id="whats-new-title">Prism {latestRelease.version}</h2></Dialog.Title>
+        <Dialog.Title asChild><h2 id="whats-new-title">Prism {latestRelease.displayVersion ?? latestRelease.version}</h2></Dialog.Title>
         <Dialog.Description asChild><p className="whats-new-copy">
           {releases.length === 1 ? latestRelease.title : `Here’s what changed since Prism ${releases[releases.length - 1]?.version}.`}
         </p></Dialog.Description>

--- a/src/whatsNew.ts
+++ b/src/whatsNew.ts
@@ -1,5 +1,7 @@
 export type WhatsNewRelease = {
   version: string;
+  displayVersion?: string;
+  previewForVersion?: string;
   title: string;
   highlights: string[];
 };
@@ -7,7 +9,20 @@ export type WhatsNewRelease = {
 // Add polished, user-facing release highlights here as each version is prepared.
 // Keeping this curated means the in-app experience stays concise even when the
 // full GitHub changelog includes maintenance and developer-facing changes.
-export const WHATS_NEW_RELEASES: WhatsNewRelease[] = [];
+const prismOneHighlights = [
+  "Library & Radio — Faster large-library browsing, incremental song loading, a persistent local catalog, automatic refresh after Navidrome scans, and steadier radio playback and metadata.",
+  "Customization — Curated color themes, album-art background wash, centered artwork controls, and a mute toggle.",
+  "Gapless & Crossfade — Preload the next queued track for smoother album sequencing, or choose a 1–12 second crossfade in Settings → Playback.",
+  "Navigation & Discovery — Native trackpad back/forward gestures, better click-through navigation across your library, and more meaningful recent listening on Home.",
+  "Desktop Polish — Secure credential storage, restored window and playback state, richer Discord activity, plus signed Windows and notarized macOS builds.",
+];
+
+export const WHATS_NEW_RELEASES: WhatsNewRelease[] = [
+  // The manual dev build still identifies as 0.5.0. Keeping this preview entry
+  // lets the final cross-platform smoke test exercise the exact 1.0 copy.
+  { version: "0.5.0", displayVersion: "1.0", previewForVersion: "1.0.0", title: "What’s New in Prism 1.0", highlights: prismOneHighlights },
+  { version: "1.0.0", title: "What’s New in Prism 1.0", highlights: prismOneHighlights },
+];
 
 function versionParts(version: string) {
   return version.replace(/^v/, "").split(".").map((part) => Number.parseInt(part, 10) || 0);
@@ -33,7 +48,9 @@ export function getCurrentReleaseNotes(currentVersion: string) {
 export function getUnreadReleaseNotes(currentVersion: string, lastSeenVersion: string) {
   if (!lastSeenVersion) return getCurrentReleaseNotes(currentVersion) ? [getCurrentReleaseNotes(currentVersion)!] : [];
 
-  return WHATS_NEW_RELEASES
+  const unreadReleases = WHATS_NEW_RELEASES
     .filter((release) => compareVersions(release.version, lastSeenVersion) > 0 && compareVersions(release.version, currentVersion) <= 0)
-    .sort((left, right) => compareVersions(right.version, left.version));
+    .filter((release) => !release.previewForVersion || !WHATS_NEW_RELEASES.some((candidate) => candidate.version === release.previewForVersion && compareVersions(candidate.version, currentVersion) <= 0));
+
+  return unreadReleases.sort((left, right) => compareVersions(right.version, left.version));
 }


### PR DESCRIPTION
## Outcome

Add the curated Prism 1.0 What’s New copy to the in-app release manifest.

## Highlights

- Library and radio reliability for large collections.
- Customization through themes and album-art wash.
- Gapless playback and optional crossfade.
- Navigation, discovery, and desktop polish.

## Preview behavior

The manual dev build currently reports version `0.5.0`, so it includes a preview entry with the finalized Prism 1.0 copy. The matching `1.0.0` entry ensures the same copy appears for the public release.

## Validation

- `npm run test`
- `npm run build`
- Preview served from this branch at `http://10.10.10.11:1420/`
