### PR TITLE
fix: Polish themed surfaces and playback settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import * as AlertDialog from "@radix-ui/react-alert-dialog";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import * as Dialog from "@radix-ui/react-dialog";
 import { deleteLibraryCatalog, readLibraryCatalog, writeLibraryCatalog } from "./libraryCatalog";
-import { getCurrentReleaseNotes, getUnreadReleaseNotes, type WhatsNewRelease } from "./whatsNew";
+import { compareVersions, getCurrentReleaseNotes, getUnreadReleaseNotes, WHATS_NEW_RELEASES, type WhatsNewRelease } from "./whatsNew";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   AlertCircle,
@@ -1959,6 +1959,10 @@ export function App() {
   const [form, setForm] = useState<NavidromeConfig>(() => loadStoredConfig() ?? emptyConfig);
   const [appSettings, setAppSettings] = useState<AppSettings>(() => loadStoredSettings());
   const [whatsNewOpen, setWhatsNewOpen] = useState(false);
+
+  useEffect(() => {
+    document.documentElement.dataset.prismTheme = appSettings.colorTheme;
+  }, [appSettings.colorTheme]);
   const [availableUpdate, setAvailableUpdate] = useState<AvailableUpdate | null>(null);
   const [updateCheckStatus, setUpdateCheckStatus] = useState<"idle" | "checking" | "up-to-date" | "available" | "error">("idle");
   const [status, setStatus] = useState<ConnectionStatus>("idle");
@@ -4955,7 +4959,6 @@ export function App() {
               updateCheckStatus={updateCheckStatus}
               onCheckForUpdates={() => void checkForUpdates()}
               canOpenWhatsNew={Boolean(currentReleaseNotes)}
-              onOpenWhatsNew={() => setWhatsNewOpen(true)}
               onSave={saveConnection}
               onReset={resetConnection}
             />
@@ -5369,7 +5372,14 @@ export function App() {
         />
       ) : null}
       {whatsNewOpen && whatsNewReleases.length ? (
-        <WhatsNewDialog releases={whatsNewReleases} onClose={dismissWhatsNew} />
+        <WhatsNewDialog
+          releases={whatsNewReleases}
+          onClose={dismissWhatsNew}
+          onOpenSettings={(tab) => {
+            dismissWhatsNew();
+            openSettings(tab);
+          }}
+        />
       ) : null}
       {playlistCreatorOpen ? (
         <PrismDialog open={playlistCreatorOpen} onOpenChange={(open) => !open && closePlaylistCreator()}>
@@ -6153,7 +6163,15 @@ function UpdateBanner({ update, onDismiss }: { update: AvailableUpdate; onDismis
   );
 }
 
-function WhatsNewDialog({ releases, onClose }: { releases: WhatsNewRelease[]; onClose: () => void }) {
+function WhatsNewDialog({
+  releases,
+  onClose,
+  onOpenSettings,
+}: {
+  releases: WhatsNewRelease[];
+  onClose: () => void;
+  onOpenSettings: (tab: "playback") => void;
+}) {
   const latestRelease = releases[0];
 
   return (
@@ -6181,6 +6199,7 @@ function WhatsNewDialog({ releases, onClose }: { releases: WhatsNewRelease[]; on
           ))}
         </div>
         <div className="whats-new-actions">
+          {latestRelease.action ? <button className="secondary-button" type="button" onClick={() => onOpenSettings(latestRelease.action!.settingsTab)}>{latestRelease.action.label}</button> : null}
           <button className="connect-button" type="button" onClick={onClose}>Got it</button>
         </div>
       </section>
@@ -6208,7 +6227,6 @@ function SettingsView({
   updateCheckStatus,
   onCheckForUpdates,
   canOpenWhatsNew,
-  onOpenWhatsNew,
   onSave,
   onReset,
 }: {
@@ -6231,7 +6249,6 @@ function SettingsView({
   updateCheckStatus: "idle" | "checking" | "up-to-date" | "available" | "error";
   onCheckForUpdates: () => void;
   canOpenWhatsNew: boolean;
-  onOpenWhatsNew: () => void;
   onSave: (event?: FormEvent<HTMLFormElement>) => Promise<void>;
   onReset: () => void;
 }) {
@@ -6390,20 +6407,27 @@ function SettingsView({
           </div>
           <Play size={18} />
         </div>
-        <label>
-          Crossfade duration
-          <select
+        <label className="settings-checkbox">
+          <input
+            type="checkbox"
+            checked={appSettings.trackTransitionSeconds > 0}
+            onChange={(event) => updateAppSettings({ ...appSettings, trackTransitionSeconds: event.target.checked ? 5 : 0 })}
+          />
+          <span>Enable crossfade</span>
+        </label>
+        {appSettings.trackTransitionSeconds > 0 ? <label>
+          Crossfade duration: {appSettings.trackTransitionSeconds} second{appSettings.trackTransitionSeconds === 1 ? "" : "s"}
+          <input
+            type="range"
+            min="1"
+            max="12"
+            step="1"
             value={appSettings.trackTransitionSeconds}
             onChange={(event) => updateAppSettings({ ...appSettings, trackTransitionSeconds: Number(event.target.value) })}
-          >
-            <option value={0}>Gapless</option>
-            {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((seconds) => (
-              <option value={seconds} key={seconds}>{seconds} second{seconds === 1 ? "" : "s"}</option>
-            ))}
-          </select>
-        </label>
+          />
+        </label> : null}
         <p className="settings-note">
-          Prism preloads the next queued track for album playback. Gapless starts it without a fade; crossfade overlaps the two tracks. Radio is unchanged.
+          Gapless playback is on by default. Prism preloads the next queued local track; crossfade is optional. Radio is unchanged.
         </p>
       </section> : null}
 
@@ -6598,12 +6622,18 @@ function SettingsView({
           <a href={PRISM_RELEASES_URL} target="_blank" rel="noreferrer"><Download size={16} /> Releases <ExternalLink size={13} /></a>
           <a href={PRISM_DISCORD_URL} target="_blank" rel="noreferrer"><MessageCircle size={16} /> Discord <ExternalLink size={13} /></a>
         </div>
-        {canOpenWhatsNew ? <div className="form-actions about-whats-new-action">
-          <button className="secondary-button" type="button" onClick={onOpenWhatsNew}>
-            <Star size={16} />
-            What’s New
-          </button>
-        </div> : null}
+        {canOpenWhatsNew ? <section className="about-changelog" aria-label="Changelog">
+          <p className="eyebrow">Changelog</p>
+          {[...WHATS_NEW_RELEASES]
+            .filter((release) => !release.previewForVersion)
+            .sort((left, right) => compareVersions(right.version, left.version))
+            .map((release) => (
+              <article key={release.version}>
+                <h4>Prism {release.displayVersion ?? release.version}</h4>
+                <ul>{release.highlights.map((highlight) => <li key={highlight}>{highlight}</li>)}</ul>
+              </article>
+            ))}
+        </section> : null}
       </section> : null}
 
       {activeTab === "advanced" ? <section className="settings-panel">

--- a/src/styles.css
+++ b/src/styles.css
@@ -113,6 +113,7 @@ textarea {
     linear-gradient(135deg, #0f1110 0%, #171514 54%, #0b0c0c 100%);
 }
 
+:root[data-prism-theme="ocean"],
 .app-shell.theme-ocean {
   --prism-accent: #73c7f2;
   --prism-accent-strong: #a9e0ff;
@@ -125,6 +126,7 @@ textarea {
   --prism-glow-bottom-rgb: 93, 198, 178;
 }
 
+:root[data-prism-theme="orchid"],
 .app-shell.theme-orchid {
   --prism-accent: #d3a5f7;
   --prism-accent-strong: #ebcaff;
@@ -137,6 +139,7 @@ textarea {
   --prism-glow-bottom-rgb: 118, 83, 166;
 }
 
+:root[data-prism-theme="evergreen"],
 .app-shell.theme-evergreen {
   --prism-accent: #a9d88a;
   --prism-accent-strong: #c9edac;
@@ -617,7 +620,8 @@ h1 {
   padding: 8px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 10px;
-  background: rgba(19, 19, 18, 0.98);
+  border: 1px solid rgba(var(--prism-accent-rgb), 0.28);
+  background: linear-gradient(145deg, rgba(var(--prism-glow-left-rgb), 0.16), rgba(19, 19, 18, 0.98) 52%, rgba(var(--prism-glow-right-rgb), 0.12));
   box-shadow: 0 24px 70px rgba(0, 0, 0, 0.52);
 }
 
@@ -689,7 +693,7 @@ h1 {
 .sidebar-playlist-menu-list button.active,
 .sidebar-playlist-menu-create:hover,
 .sidebar-playlist-menu-create:focus-visible {
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(var(--prism-accent-rgb), 0.18);
   color: #fff;
 }
 
@@ -4231,10 +4235,10 @@ button.similar-chip:hover,
   max-height: calc(100dvh - 56px);
   overflow: auto;
   padding: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(var(--prism-accent-rgb), 0.32);
   border-radius: 8px;
   background:
-    linear-gradient(135deg, rgba(29, 29, 27, 0.98), rgba(16, 18, 18, 0.98)),
+    linear-gradient(135deg, rgba(var(--prism-glow-left-rgb), 0.2), rgba(16, 18, 18, 0.98) 54%, rgba(var(--prism-glow-right-rgb), 0.15)),
     #111111;
   box-shadow: 0 26px 92px rgba(0, 0, 0, 0.44);
 }
@@ -4397,6 +4401,34 @@ button.similar-chip:hover,
   display: flex;
   justify-content: flex-end;
   margin-top: 24px;
+}
+
+.about-changelog {
+  display: grid;
+  gap: 12px;
+  margin-top: 28px;
+  padding-top: 22px;
+  border-top: 1px solid rgba(var(--prism-accent-rgb), 0.22);
+}
+
+.about-changelog article {
+  display: grid;
+  gap: 8px;
+}
+
+.about-changelog h4 {
+  color: var(--prism-accent-strong);
+  font-size: 14px;
+}
+
+.about-changelog ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+  color: rgba(244, 241, 236, 0.72);
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .wizard-status.bad {
@@ -5347,9 +5379,9 @@ button.similar-chip:hover,
   width: 268px;
   max-height: min(420px, calc(100vh - 24px));
   padding: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(var(--prism-accent-rgb), 0.28);
   border-radius: 8px;
-  background: rgba(17, 17, 16, 0.98);
+  background: linear-gradient(145deg, rgba(var(--prism-glow-left-rgb), 0.16), rgba(17, 17, 16, 0.98) 52%, rgba(var(--prism-glow-right-rgb), 0.12));
   box-shadow: 0 24px 70px rgba(0, 0, 0, 0.52);
   overflow: hidden;
 }
@@ -5428,9 +5460,9 @@ button.similar-chip:hover,
   width: 248px;
   max-height: min(360px, calc(100vh - 24px));
   padding: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(var(--prism-accent-rgb), 0.28);
   border-radius: 8px;
-  background: rgba(17, 17, 16, 0.98);
+  background: linear-gradient(145deg, rgba(var(--prism-glow-left-rgb), 0.16), rgba(17, 17, 16, 0.98) 52%, rgba(var(--prism-glow-right-rgb), 0.12));
   box-shadow: 0 24px 70px rgba(0, 0, 0, 0.52);
   overflow: hidden;
 }
@@ -5439,7 +5471,7 @@ button.similar-chip:hover,
 .song-context-action:focus-visible:not(:disabled),
 .song-context-list button:hover:not(:disabled),
 .song-context-list button:focus-visible:not(:disabled) {
-  background: rgba(255, 255, 255, 0.09);
+  background: rgba(var(--prism-accent-rgb), 0.18);
   color: #fff;
 }
 

--- a/src/whatsNew.ts
+++ b/src/whatsNew.ts
@@ -4,24 +4,25 @@ export type WhatsNewRelease = {
   previewForVersion?: string;
   title: string;
   highlights: string[];
+  action?: { label: string; settingsTab: "playback" };
 };
 
 // Add polished, user-facing release highlights here as each version is prepared.
 // Keeping this curated means the in-app experience stays concise even when the
 // full GitHub changelog includes maintenance and developer-facing changes.
 const prismOneHighlights = [
-  "Library & Radio — Faster large-library browsing, incremental song loading, a persistent local catalog, automatic refresh after Navidrome scans, and steadier radio playback and metadata.",
-  "Customization — Curated color themes, album-art background wash, centered artwork controls, and a mute toggle.",
-  "Gapless & Crossfade — Preload the next queued track for smoother album sequencing, or choose a 1–12 second crossfade in Settings → Playback.",
-  "Navigation & Discovery — Native trackpad back/forward gestures, better click-through navigation across your library, and more meaningful recent listening on Home.",
-  "Desktop Polish — Secure credential storage, restored window and playback state, richer Discord activity, plus signed Windows and notarized macOS builds.",
+  "Library & Radio: Faster large-library browsing, incremental song loading, a persistent local catalog, automatic refresh after Navidrome scans, and steadier radio playback and metadata.",
+  "Customization: Curated color themes, album-art background wash, centered artwork controls, and a mute toggle.",
+  "Gapless & Crossfade: Preload the next queued track for smoother album sequencing, or enable a 1–12 second crossfade in Settings.",
+  "Navigation & Discovery: Native trackpad back/forward gestures, better click-through navigation across your library, and more meaningful recent listening on Home.",
+  "Desktop Polish: Secure credential storage, restored window and playback state, richer Discord activity, plus signed Windows and notarized macOS builds.",
 ];
 
 export const WHATS_NEW_RELEASES: WhatsNewRelease[] = [
   // The manual dev build still identifies as 0.5.0. Keeping this preview entry
   // lets the final cross-platform smoke test exercise the exact 1.0 copy.
-  { version: "0.5.0", displayVersion: "1.0", previewForVersion: "1.0.0", title: "What’s New in Prism 1.0", highlights: prismOneHighlights },
-  { version: "1.0.0", title: "What’s New in Prism 1.0", highlights: prismOneHighlights },
+  { version: "0.5.0", displayVersion: "1.0", previewForVersion: "1.0.0", title: "What’s New in Prism 1.0", highlights: prismOneHighlights, action: { label: "Open Playback Settings", settingsTab: "playback" } },
+  { version: "1.0.0", title: "What’s New in Prism 1.0", highlights: prismOneHighlights, action: { label: "Open Playback Settings", settingsTab: "playback" } },
 ];
 
 function versionParts(version: string) {


### PR DESCRIPTION
## Outcome

Finish the Prism 1.0 visual and playback-settings polish.

## Changes

- Apply the active theme to modal, dropdown, and context-menu surfaces, including Radix portals.
- Replace em dashes in the curated release copy and add an in-modal Playback Settings action.
- Show curated release notes as the About-page changelog.
- Keep gapless as the default and make crossfade an opt-in 1–12 second slider.

## Validation

- `npm run test`
- `npm run build`
- Preview served from this branch at `http://10.10.10.11:1420/`
