### PR TITLE
fix: Remove release-note settings action

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5372,14 +5372,7 @@ export function App() {
         />
       ) : null}
       {whatsNewOpen && whatsNewReleases.length ? (
-        <WhatsNewDialog
-          releases={whatsNewReleases}
-          onClose={dismissWhatsNew}
-          onOpenSettings={(tab) => {
-            dismissWhatsNew();
-            openSettings(tab);
-          }}
-        />
+        <WhatsNewDialog releases={whatsNewReleases} onClose={dismissWhatsNew} />
       ) : null}
       {playlistCreatorOpen ? (
         <PrismDialog open={playlistCreatorOpen} onOpenChange={(open) => !open && closePlaylistCreator()}>
@@ -6163,15 +6156,7 @@ function UpdateBanner({ update, onDismiss }: { update: AvailableUpdate; onDismis
   );
 }
 
-function WhatsNewDialog({
-  releases,
-  onClose,
-  onOpenSettings,
-}: {
-  releases: WhatsNewRelease[];
-  onClose: () => void;
-  onOpenSettings: (tab: "playback") => void;
-}) {
+function WhatsNewDialog({ releases, onClose }: { releases: WhatsNewRelease[]; onClose: () => void }) {
   const latestRelease = releases[0];
 
   return (
@@ -6199,7 +6184,6 @@ function WhatsNewDialog({
           ))}
         </div>
         <div className="whats-new-actions">
-          {latestRelease.action ? <button className="secondary-button" type="button" onClick={() => onOpenSettings(latestRelease.action!.settingsTab)}>{latestRelease.action.label}</button> : null}
           <button className="connect-button" type="button" onClick={onClose}>Got it</button>
         </div>
       </section>

--- a/src/whatsNew.ts
+++ b/src/whatsNew.ts
@@ -4,7 +4,6 @@ export type WhatsNewRelease = {
   previewForVersion?: string;
   title: string;
   highlights: string[];
-  action?: { label: string; settingsTab: "playback" };
 };
 
 // Add polished, user-facing release highlights here as each version is prepared.
@@ -21,8 +20,8 @@ const prismOneHighlights = [
 export const WHATS_NEW_RELEASES: WhatsNewRelease[] = [
   // The manual dev build still identifies as 0.5.0. Keeping this preview entry
   // lets the final cross-platform smoke test exercise the exact 1.0 copy.
-  { version: "0.5.0", displayVersion: "1.0", previewForVersion: "1.0.0", title: "What’s New in Prism 1.0", highlights: prismOneHighlights, action: { label: "Open Playback Settings", settingsTab: "playback" } },
-  { version: "1.0.0", title: "What’s New in Prism 1.0", highlights: prismOneHighlights, action: { label: "Open Playback Settings", settingsTab: "playback" } },
+  { version: "0.5.0", displayVersion: "1.0", previewForVersion: "1.0.0", title: "What’s New in Prism 1.0", highlights: prismOneHighlights },
+  { version: "1.0.0", title: "What’s New in Prism 1.0", highlights: prismOneHighlights },
 ];
 
 function versionParts(version: string) {


### PR DESCRIPTION
## Outcome

Remove the What’s New modal’s Playback Settings action and its unused release-manifest metadata.

## Validation

- `npm run test`
- `npm run build`
