### PR TITLE
feat: Show the Beacon install ID in About

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,9 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   AlertCircle,
   CalendarDays,
+  Check,
   Code2,
+  Copy,
   ChevronLeft,
   ChevronRight,
   CheckCircle2,
@@ -6237,6 +6239,36 @@ function SettingsView({
   onReset: () => void;
 }) {
   const [newRadioStationUrl, setNewRadioStationUrl] = useState("");
+  const [installIdCopied, setInstallIdCopied] = useState(false);
+  const [installId, setInstallId] = useState<string | null>(() => {
+    try {
+      return localStorage.getItem(INSTALL_ID_KEY);
+    } catch {
+      return null;
+    }
+  });
+
+  useEffect(() => {
+    if (activeTab !== "about") return;
+
+    try {
+      setInstallId(localStorage.getItem(INSTALL_ID_KEY));
+    } catch {
+      setInstallId(null);
+    }
+  }, [activeTab]);
+
+  async function copyInstallId() {
+    if (!installId) return;
+
+    try {
+      await navigator.clipboard.writeText(installId);
+      setInstallIdCopied(true);
+      window.setTimeout(() => setInstallIdCopied(false), 2_000);
+    } catch {
+      setInstallIdCopied(false);
+    }
+  }
 
   function setDefaultAlbumView(mode: AlbumViewMode) {
     updateAppSettings({ ...appSettings, defaultAlbumView: mode });
@@ -6583,6 +6615,16 @@ function SettingsView({
             <span className="settings-label">Installed version</span>
             <strong>v{APP_VERSION}</strong>
             <span className="about-commit-sha" title={`Commit ${APP_COMMIT_SHA}`}>SHA {APP_COMMIT_SHA}</span>
+            <div className="about-install-id">
+              <span className="settings-label">Beacon install ID</span>
+              {installId ? <div className="about-install-id-value">
+                <code title={installId}>{installId}</code>
+                <button className="secondary-button compact-button" type="button" onClick={copyInstallId}>
+                  {installIdCopied ? <Check size={14} /> : <Copy size={14} />}
+                  {installIdCopied ? "Copied" : "Copy ID"}
+                </button>
+              </div> : <span className="settings-note">Created when analytics is enabled.</span>}
+            </div>
           </div>
           <div className="about-update-action">
             {availableUpdate ? <a className="connect-button compact-button" href={availableUpdate.releaseUrl} target="_blank" rel="noreferrer">

--- a/src/styles.css
+++ b/src/styles.css
@@ -2960,7 +2960,7 @@ button.similar-chip:hover,
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   align-items: center;
   gap: 14px;
-  padding: 14px;
+  padding: 16px 14px;
   border: 1px solid rgba(var(--prism-highlight-rgb), 0.16);
   border-radius: 10px;
   background: linear-gradient(135deg, rgba(var(--prism-highlight-rgb), 0.11), rgba(255, 255, 255, 0.035));
@@ -2978,6 +2978,33 @@ button.similar-chip:hover,
   font-weight: 600;
   letter-spacing: 0.04em;
   white-space: nowrap;
+}
+
+.about-install-id {
+  display: grid;
+  gap: 5px;
+  margin-top: 8px;
+}
+
+.about-install-id-value {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.about-install-id-value code {
+  overflow: hidden;
+  min-width: 0;
+  color: rgba(244, 241, 236, 0.72);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.about-install-id .settings-note {
+  margin: 0;
 }
 
 .settings-label {


### PR DESCRIPTION
## Outcome

Adds a copyable Beacon install ID to the About page, directly beneath the installed version.

## Changes

- Reads the existing local install ID without creating a new identifier.
- Shows a concise explanation until analytics has generated an ID.
- Adds copy confirmation and expands the version card slightly to keep the new detail balanced.

## Validation

- `npm run test` (TypeScript and ESLint)
- `npm run build`
- Independent code review: clean

## Rollout and rollback

No migration or backend change. Removing the client change restores the prior About card without affecting any stored ID or Beacon data.
