### PR TITLE
chore: Set the Prism 1.0.0 release version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "node",
       "package-name": "prism-player",
+      "release-as": "1.0.0",
       "bump-minor-pre-major": true,
       "include-component-in-tag": false,
       "extra-files": [


### PR DESCRIPTION
## Purpose

Forces the pending Release Please release from v0.6.0 to Prism Player v1.0.0.

Release Please otherwise treats the feature set accumulated after v0.5.0 as a pre-1.0 minor release. This explicit one-time target matches the approved release intent.

## Change

- Set `release-as` to `1.0.0` in the Release Please package configuration.

## Validation

- Confirmed the configuration remains valid JSON.
- Checked the diff for whitespace errors.

## Follow-up

After this PR is merged, Release Please should update #161 to `chore(release): release 1.0.0`. That PR still requires an editorial pass on release notes and Kyle's manual merge.
