### PR TITLE
chore: Set the Prism 1.0.0 release version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "node",
       "package-name": "prism-player",
+      "release-as": "1.0.0",
       "bump-minor-pre-major": true,
       "include-component-in-tag": false,
       "extra-files": [


### PR DESCRIPTION
## Purpose

Forces the pending Release Please release from v0.6.0 to Prism Player v1.0.0.

This passes through `dev` first, as required by the repository's protected release-promotion workflow.

## Change

- Set `release-as` to `1.0.0` in the Release Please package configuration.

## Validation

- Confirmed the configuration remains valid JSON.
- Checked the diff for whitespace errors.

## Follow-up

After this PR is merged to `dev`, a `dev` → `release` promotion PR will carry this one-line override. Release Please should then update #161 to `chore(release): release 1.0.0`, which will receive an editorial pass before Kyle's manual merge.
