### PR TITLE
release: Promote the Prism 1.0.0 version target

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "node",
       "package-name": "prism-player",
+      "release-as": "1.0.0",
       "bump-minor-pre-major": true,
       "include-component-in-tag": false,
       "extra-files": [


### PR DESCRIPTION
## Release promotion

Promotes the explicit Prism Player v1.0.0 Release Please target from `dev` to `release`.

## Validation

- The v1.0.0 override PR #163 passed its PR checks.
- The resulting `dev` commit passed fresh CI and Security workflows.
- This PR contains only the one-line Release Please `release-as: 1.0.0` configuration change.

## Next step

Use **Create a merge commit**. Release Please should then update #161 from v0.6.0 to v1.0.0. That generated release PR will receive a final release-note editorial pass before Kyle manually merges it to publish the installers.
