### PR TITLE
feat: Publish Linux installers with release checksums

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ on:
           - all
           - macos
           - windows
+          - linux
 
 permissions:
   contents: write
@@ -38,7 +39,7 @@ concurrency:
 jobs:
   macos:
     name: macOS DMG
-    if: inputs.announce_only != true && (github.event_name == 'release' || inputs.platform != 'windows')
+    if: inputs.announce_only != true && (github.event_name == 'release' || inputs.platform == 'all' || inputs.platform == 'macos')
     runs-on: macos-latest
 
     steps:
@@ -219,7 +220,7 @@ jobs:
 
   windows:
     name: Windows installer
-    if: inputs.announce_only != true && (github.event_name == 'release' || inputs.platform != 'macos')
+    if: inputs.announce_only != true && (github.event_name == 'release' || inputs.platform == 'all' || inputs.platform == 'windows')
     runs-on: windows-latest
     # Azure's federated credential is scoped to this protected GitHub
     # environment, rather than a branch or release tag.
@@ -327,9 +328,144 @@ jobs:
             gh release upload "$RELEASE_TAG" "$installer" --clobber
           done
 
+  linux:
+    name: Linux packages
+    if: inputs.announce_only != true && (github.event_name == 'release' || inputs.platform == 'all' || inputs.platform == 'linux')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.source_ref || github.ref }}
+
+      - name: Resolve artifact name
+        id: artifact
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref || inputs.source_ref }}
+        run: |
+          if [[ -n "$RELEASE_TAG" ]]; then
+            suffix="$RELEASE_TAG"
+          else
+            suffix="${GITHUB_REF_NAME}"
+          fi
+          suffix="$(echo "$suffix" | tr '/\\:*?\"<>|' '-')"
+          echo "suffix=$suffix" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux Tauri dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            curl \
+            file \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            wget
+
+      - name: Install frontend dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Build Linux packages
+        run: npm run tauri:build -- --bundles appimage,deb
+
+      - name: Upload Linux package artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: prism-player-${{ steps.artifact.outputs.suffix }}-linux-packages
+          path: |
+            src-tauri/target/release/bundle/appimage/*.AppImage
+            src-tauri/target/release/bundle/deb/*.deb
+          if-no-files-found: error
+          retention-days: ${{ github.event_name == 'release' && 90 || 14 }}
+
+      - name: Attach Linux packages to GitHub release
+        if: github.event_name == 'release' || inputs.ref != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref }}
+        run: |
+          gh release upload "$RELEASE_TAG" \
+            src-tauri/target/release/bundle/appimage/*.AppImage \
+            src-tauri/target/release/bundle/deb/*.deb \
+            --clobber
+
+  checksums:
+    name: Release checksums
+    needs: [macos, windows, linux]
+    if: always() && inputs.announce_only != true && (github.event_name == 'release' || inputs.ref != '' || inputs.source_ref != '')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Resolve artifact name
+        id: artifact
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref || inputs.source_ref }}
+        run: |
+          if [[ -n "$RELEASE_TAG" ]]; then
+            suffix="$RELEASE_TAG"
+          else
+            suffix="${GITHUB_REF_NAME}"
+          fi
+          suffix="$(echo "$suffix" | tr '/\\:*?\"<>|' '-')"
+          echo "suffix=$suffix" >> "$GITHUB_OUTPUT"
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: prism-player-*-*
+          path: release-artifacts
+          merge-multiple: true
+
+      - name: Create checksum manifest
+        id: manifest
+        env:
+          ARTIFACT_SUFFIX: ${{ steps.artifact.outputs.suffix }}
+        run: |
+          cd release-artifacts
+          manifest="Prism-player-${ARTIFACT_SUFFIX}-checksums.txt"
+          mapfile -d '' assets < <(find . -type f \( \
+            -name '*.dmg' -o -name '*.exe' -o -name '*.AppImage' -o -name '*.deb' \
+          \) -print0 | sort -z)
+          if [[ "${#assets[@]}" -eq 0 ]]; then
+            echo "::error::No release assets were downloaded for checksumming."
+            exit 1
+          fi
+          shasum -a 256 "${assets[@]}" > "$manifest"
+          echo "path=release-artifacts/$manifest" >> "$GITHUB_OUTPUT"
+
+      - name: Upload checksum artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: prism-player-${{ steps.artifact.outputs.suffix }}-checksums
+          path: ${{ steps.manifest.outputs.path }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Attach checksum manifest to GitHub release
+        if: github.event_name == 'release' || inputs.ref != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref }}
+        run: gh release upload "$RELEASE_TAG" "${{ steps.manifest.outputs.path }}" --clobber
+
   announce-discord:
     name: Discord release announcement
-    needs: [macos, windows]
+    needs: [macos, windows, linux, checksums]
     if: always() && (github.event_name == 'release' || inputs.ref != '') && vars.DISABLE_DISCORD_RELEASE_ANNOUNCEMENT != 'true'
     runs-on: ubuntu-latest
     permissions:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -497,8 +497,6 @@ const RADIO_RECONNECT_MAX_MS = 30_000;
 const RADIO_REQUEST_POLL_INTERVAL_MS = 1500;
 const RADIO_REQUEST_POLL_DEADLINE_MS = 60_000;
 const API_VERSION = "1.16.1";
-const RADIO_WAVEFORM_BAR_COUNT = 96;
-const idleRadioWaveformBars = Array.from({ length: RADIO_WAVEFORM_BAR_COUNT }, (_, index) => 18 + ((index * 17) % 56));
 
 const emptyConfig: NavidromeConfig = {
   serverUrl: "",
@@ -2033,7 +2031,6 @@ export function App() {
   const [radioVolume, setRadioVolume] = useState(appSettings.lastVolume);
   const [isMuted, setIsMuted] = useState(false);
   const [radioClockNow, setRadioClockNow] = useState(() => Date.now());
-  const [radioWaveformBars, setRadioWaveformBars] = useState<number[]>(idleRadioWaveformBars);
   const [radioPopover, setRadioPopover] = useState<"schedule" | "request" | "booth" | null>(null);
   const [radioLikeStatus, setRadioLikeStatus] = useState<RadioLikeStatus | null>(null);
   const [radioLikeBusy, setRadioLikeBusy] = useState(false);
@@ -2074,9 +2071,6 @@ export function App() {
   const radioRetryCountRef = useRef(0);
   const radioGenerationRef = useRef(0);
   const radioWatchdogArmedAtRef = useRef(0);
-  const radioAudioContextRef = useRef<AudioContext | null>(null);
-  const radioAnalyserRef = useRef<AnalyserNode | null>(null);
-  const radioAnalyserSourceRef = useRef<MediaElementAudioSourceNode | null>(null);
   const scrobbledPlayRef = useRef("");
   const locallyRecordedPlayRef = useRef("");
   const pendingResumePositionRef = useRef(initialPlaybackSnapshot?.position ?? 0);
@@ -4240,70 +4234,6 @@ export function App() {
   }, [isRadioPlaying]);
 
   useEffect(() => {
-    if (!isRadioPlaying || appSettings.lowPerformanceMode) {
-      setRadioWaveformBars(idleRadioWaveformBars);
-      return;
-    }
-
-    const audio = radioAudioRef.current;
-    const AudioContextConstructor = window.AudioContext;
-    if (!audio || !AudioContextConstructor) {
-      setRadioWaveformBars(idleRadioWaveformBars);
-      return;
-    }
-
-    let frameId = 0;
-    let cancelled = false;
-
-    try {
-      const audioContext = radioAudioContextRef.current ?? new AudioContextConstructor();
-      radioAudioContextRef.current = audioContext;
-
-      if (!radioAnalyserSourceRef.current) {
-        radioAnalyserSourceRef.current = audioContext.createMediaElementSource(audio);
-      }
-
-      if (!radioAnalyserRef.current) {
-        const analyser = audioContext.createAnalyser();
-        analyser.fftSize = 256;
-        analyser.smoothingTimeConstant = 0.82;
-        radioAnalyserSourceRef.current.connect(analyser);
-        analyser.connect(audioContext.destination);
-        radioAnalyserRef.current = analyser;
-      }
-
-      void audioContext.resume();
-
-      const analyser = radioAnalyserRef.current;
-      const frequencyData = new Uint8Array(analyser.frequencyBinCount);
-
-      function drawWaveform() {
-        if (cancelled) return;
-        analyser.getByteFrequencyData(frequencyData);
-        const bucketSize = Math.max(1, Math.floor(frequencyData.length / RADIO_WAVEFORM_BAR_COUNT));
-        const nextBars = Array.from({ length: RADIO_WAVEFORM_BAR_COUNT }, (_, barIndex) => {
-          const start = barIndex * bucketSize;
-          const bucket = frequencyData.slice(start, start + bucketSize);
-          const peak = bucket.reduce((max, value) => Math.max(max, value), 0);
-          return Math.round(clampNumber((peak / 255) * 100, 8, 100));
-        });
-
-        setRadioWaveformBars(nextBars);
-        frameId = window.requestAnimationFrame(drawWaveform);
-      }
-
-      drawWaveform();
-    } catch {
-      setRadioWaveformBars(idleRadioWaveformBars);
-    }
-
-    return () => {
-      cancelled = true;
-      if (frameId) window.cancelAnimationFrame(frameId);
-    };
-  }, [appSettings.lowPerformanceMode, isRadioPlaying]);
-
-  useEffect(() => {
     if (!currentTrack) return;
     setLastPlayedTrack(currentTrack);
     localStorage.setItem(LAST_PLAYED_TRACK_KEY, JSON.stringify(currentTrack));
@@ -4994,7 +4924,6 @@ export function App() {
               radioSchedule={radioSchedule}
               radioStatus={radioStatus}
               radioMessage={radioMessage}
-              radioWaveformBars={radioWaveformBars}
               tuneInRadio={tuneInRadio}
               onStartRadio={() => {
                 selectView("radio");
@@ -5092,7 +5021,6 @@ export function App() {
         />
         <audio
           ref={radioAudioRef}
-          crossOrigin="anonymous"
           preload="none"
           onPlay={() => {
             setIsRadioTuning(false);
@@ -6924,7 +6852,6 @@ function RadioView({
   schedule,
   status,
   message,
-  waveformBars,
   tuneIn,
   onAddFirstStation,
 }: {
@@ -6936,7 +6863,6 @@ function RadioView({
   schedule: RadioSchedulePayload | null;
   status: RadioStatus;
   message: string;
-  waveformBars: number[];
   tuneIn: () => Promise<void>;
   onAddFirstStation: (stationUrl: string) => Promise<void>;
 }) {
@@ -7080,14 +7006,6 @@ function RadioView({
           </div>
         </div>
 
-        {visualEffectsEnabled ? (
-          <div className={`radio-waveform ${isPlaying ? "playing" : ""}`} aria-hidden="true">
-            {waveformBars.map((bar, index) => (
-              <span key={index} style={{ "--bar": `${bar}%` } as CSSProperties} />
-            ))}
-          </div>
-        ) : null}
-
         <div className="radio-broadcast-details" aria-label="Station details">
           <div>
             <span>In the Booth</span>
@@ -7124,7 +7042,6 @@ function LibraryView({
   radioSchedule,
   radioStatus,
   radioMessage,
-  radioWaveformBars,
   tuneInRadio,
   onStartRadio,
   onAddFirstRadioStation,
@@ -7195,7 +7112,6 @@ function LibraryView({
   radioSchedule: RadioSchedulePayload | null;
   radioStatus: RadioStatus;
   radioMessage: string;
-  radioWaveformBars: number[];
   tuneInRadio: () => Promise<void>;
   onStartRadio: () => void;
   onAddFirstRadioStation: (stationUrl: string) => Promise<void>;
@@ -7277,7 +7193,6 @@ function LibraryView({
         schedule={radioSchedule}
         status={radioStatus}
         message={radioMessage}
-        waveformBars={radioWaveformBars}
         tuneIn={tuneInRadio}
         onAddFirstStation={onAddFirstRadioStation}
       />

--- a/src/styles.css
+++ b/src/styles.css
@@ -3644,39 +3644,6 @@ button.similar-chip:hover,
   }
 }
 
-.radio-waveform {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  grid-column: 1 / -1;
-  grid-row: 3;
-  grid-template-columns: repeat(96, minmax(2px, 1fr));
-  align-items: flex-end;
-  align-self: end;
-  gap: 2px;
-  width: 100%;
-  height: 54px;
-  margin-top: 0;
-  padding-top: 10px;
-  overflow: hidden;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.11);
-  opacity: 0.86;
-}
-
-.radio-waveform span {
-  width: 100%;
-  height: var(--bar);
-  min-height: 7px;
-  border-radius: 5px 5px 0 0;
-  background: linear-gradient(180deg, rgba(var(--prism-highlight-rgb), 0.94), rgba(var(--prism-highlight-rgb), 0.38));
-  transform-origin: bottom;
-  transition: height 80ms linear, opacity 120ms ease;
-}
-
-.radio-waveform:not(.playing) span {
-  opacity: 0.42;
-}
-
 .radio-controls {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Outcome

Adds Linux release artifacts and makes Subwave radio use the native media path, avoiding the CORS-bound waveform pipeline that fails in Linux WebKitGTK.

## Changes

- Build x64 AppImage and Debian (`.deb`) packages on GitHub-hosted Linux runners.
- Add Linux to the manual build-platform selector.
- Attach Linux packages to published GitHub releases.
- Generate and attach `Prism-player-<tag>-checksums.txt` after macOS, Windows, and Linux artifacts finish.
- Make the release announcement wait for all packages and the checksum manifest.
- Remove the Subwave waveform analyzer and its cross-origin audio setting so radio playback uses the platform-native audio pipeline.

## Validation

- `git diff --check`
- `npm test` (TypeScript and ESLint)
- `npm run build`
- Workflow YAML parsed successfully.
- Verified the configured artifact action versions are current.

## Notes

Linux packages are not publisher-signed in this initial GitHub Releases lane. The checksum manifest verifies downloaded assets; Tauri updater signing will be added separately if and when in-app updates are enabled.

## Rollback

Revert the workflow changes to stop producing Linux assets and checksum manifests. Revert the radio playback commit to restore the waveform and its CORS-bound audio graph.
