### PR TITLE
feat: Polish search, macOS navigation, and playback

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -234,10 +234,10 @@ pub fn run() {
                     .expect("main Prism webview should exist during setup");
                 main_webview.with_webview(|webview| unsafe {
                     let view: &objc2_web_kit::WKWebView = &*webview.inner().cast();
-                    // WebKit's native history gesture slides the entire app
-                    // surface, which feels like moving the window rather than
-                    // navigating Prism. Keep navigation in Prism's controls.
-                    view.setAllowsBackForwardNavigationGestures(false);
+                    // Let macOS own the trackpad history gesture. Prism's
+                    // browser state is kept in the WebView history stack, so
+                    // WebKit will dispatch the matching popstate event.
+                    view.setAllowsBackForwardNavigationGestures(true);
                 })?;
             }
 
@@ -257,6 +257,10 @@ pub fn run() {
         .run(|app, event| {
             if matches!(event, tauri::RunEvent::Ready) {
                 ensure_main_window_is_visible(app);
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                }
             }
         });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,7 @@ use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
 use keyring::Entry;
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
-use tauri::{Emitter, Manager};
+use tauri::{Emitter, Manager, PhysicalPosition};
 
 const DISCORD_CLIENT_ID: &str = "1537904664740364418";
 const KEYRING_SERVICE: &str = "com.kylejschultz.prism-player";
@@ -161,6 +161,64 @@ fn clear_discord_presence_in_background(app: &tauri::AppHandle) {
     }
 }
 
+/// Window-state considers any corner on any display as visible. That leaves a
+/// restored window effectively stranded at a display edge after a monitor
+/// layout changes. Keep a saved placement only when at least half of the
+/// window is actually visible; otherwise center it on the most-visible display.
+fn ensure_main_window_is_visible(app: &tauri::AppHandle) {
+    let Some(window) = app.get_webview_window("main") else {
+        return;
+    };
+    let (Ok(position), Ok(size), Ok(monitors)) = (
+        window.outer_position(),
+        window.outer_size(),
+        window.available_monitors(),
+    ) else {
+        return;
+    };
+
+    let window_area = i64::from(size.width) * i64::from(size.height);
+    if window_area == 0 {
+        return;
+    }
+
+    let mut best_monitor = None;
+    let mut best_visible_area = 0_i64;
+    for monitor in monitors {
+        let monitor_position = monitor.position();
+        let monitor_size = monitor.size();
+        let overlap_width = (position.x + size.width as i32)
+            .min(monitor_position.x + monitor_size.width as i32)
+            .saturating_sub(position.x.max(monitor_position.x));
+        let overlap_height = (position.y + size.height as i32)
+            .min(monitor_position.y + monitor_size.height as i32)
+            .saturating_sub(position.y.max(monitor_position.y));
+        let visible_area = i64::from(overlap_width) * i64::from(overlap_height);
+
+        if visible_area > best_visible_area {
+            best_visible_area = visible_area;
+            best_monitor = Some(monitor);
+        }
+    }
+
+    if best_visible_area * 2 >= window_area {
+        return;
+    }
+
+    let monitor = best_monitor
+        .or_else(|| window.primary_monitor().ok().flatten())
+        .or_else(|| window.current_monitor().ok().flatten());
+    let Some(monitor) = monitor else {
+        return;
+    };
+
+    let monitor_position = monitor.position();
+    let monitor_size = monitor.size();
+    let x = monitor_position.x + (monitor_size.width.saturating_sub(size.width) / 2) as i32;
+    let y = monitor_position.y + (monitor_size.height.saturating_sub(size.height) / 2) as i32;
+    let _ = window.set_position(PhysicalPosition::new(x, y));
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -176,7 +234,10 @@ pub fn run() {
                     .expect("main Prism webview should exist during setup");
                 main_webview.with_webview(|webview| unsafe {
                     let view: &objc2_web_kit::WKWebView = &*webview.inner().cast();
-                    view.setAllowsBackForwardNavigationGestures(true);
+                    // WebKit's native history gesture slides the entire app
+                    // surface, which feels like moving the window rather than
+                    // navigating Prism. Keep navigation in Prism's controls.
+                    view.setAllowsBackForwardNavigationGestures(false);
                 })?;
             }
 
@@ -191,6 +252,11 @@ pub fn run() {
             clear_navidrome_password,
             get_native_architecture
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running Prism Player");
+        .build(tauri::generate_context!())
+        .expect("error while building Prism Player")
+        .run(|app, event| {
+            if matches!(event, tauri::RunEvent::Ready) {
+                ensure_main_window_is_visible(app);
+            }
+        });
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "height": 780,
         "minWidth": 980,
         "minHeight": 640,
-        "resizable": true
+        "resizable": true,
+        "visible": false
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7921,6 +7921,9 @@ function SearchResultsView({
   return (
     <div className="search-results">
       <section className="search-summary">
+        <div>
+          <h4>{trimmedQuery}</h4>
+        </div>
         <div className="search-counts" aria-label="Filter results by type">
           {filters.map(([filter, label, count]) => (
             <button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7886,7 +7886,6 @@ function SearchResultsView({
   const trimmedQuery = query.trim();
   const totalResults = results.artists.length + results.albums.length + results.songs.length + results.playlists.length;
   const [resultFilter, setResultFilter] = useState<"all" | "songs" | "albums" | "artists" | "playlists">("all");
-  const [expandedSections, setExpandedSections] = useState<Set<"songs" | "albums" | "artists" | "playlists">>(() => new Set());
   const filters = [
     ["all", "All", totalResults],
     ["songs", "Songs", results.songs.length],
@@ -7895,10 +7894,12 @@ function SearchResultsView({
     ["playlists", "Playlists", results.playlists.length],
   ] as const;
   const shows = (type: Exclude<typeof resultFilter, "all">) => resultFilter === "all" || resultFilter === type;
-  const visible = <T,>(type: "songs" | "albums" | "artists" | "playlists", items: T[]) => expandedSections.has(type) ? items : items.slice(0, previewLimit);
-  const canShowMore = <T,>(type: "songs" | "albums" | "artists" | "playlists", items: T[]) => !expandedSections.has(type) && items.length > previewLimit;
+  const visible = <T,>(type: "songs" | "albums" | "artists" | "playlists", items: T[]) => resultFilter === type ? items : items.slice(0, previewLimit);
+  const canShowMore = <T,>(type: "songs" | "albums" | "artists" | "playlists", items: T[]) => resultFilter !== type && items.length > previewLimit;
   const showMore = (type: "songs" | "albums" | "artists" | "playlists") => {
-    setExpandedSections((sections) => new Set(sections).add(type));
+    // A full section is its own focused result view. Keeping its source array
+    // intact preserves Navidrome's relevance order from preview to full list.
+    setResultFilter(type);
   };
 
   if (trimmedQuery.length < 2) {
@@ -8001,6 +8002,7 @@ function SearchResultsView({
             onPlaySong={onPlaySong}
             onQueueSong={onQueueSong}
             onSongContextMenu={onSongContextMenu}
+            preserveResultOrder
           />
           {canShowMore("songs", results.songs) ? <button className="search-see-more" type="button" onClick={() => showMore("songs")}>See more songs ({results.songs.length - previewLimit})</button> : null}
         </section>
@@ -8054,6 +8056,7 @@ function SearchSongList({
   onPlaySong,
   onQueueSong,
   onSongContextMenu,
+  preserveResultOrder = false,
 }: {
   songs: Song[];
   currentTrack: Song | null;
@@ -8065,12 +8068,13 @@ function SearchSongList({
   onPlaySong: (song: Song) => void;
   onQueueSong: (song: Song) => void;
   onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
+  preserveResultOrder?: boolean;
 }) {
   const { isSelected, selectTrack, selectedSongs, handleKeyDown, listRef } = useTrackSelection(songs);
-  const [sortKey, setSortKey] = useState<SongSortKey>("title");
+  const [sortKey, setSortKey] = useState<SongSortKey | null>(preserveResultOrder ? null : "title");
   const [sortDirection, setSortDirection] = useState<SongSortDirection>("asc");
   const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
-  const sortedSongs = useMemo(() => sortSongs(songs, sortKey, sortDirection), [songs, sortKey, sortDirection]);
+  const sortedSongs = useMemo(() => sortKey ? sortSongs(songs, sortKey, sortDirection) : songs, [songs, sortKey, sortDirection]);
   const songIndexes = useMemo(() => new Map(songs.map((song, index) => [song.id, index])), [songs]);
   const virtualizer = useVirtualizer({
     count: sortedSongs.length,
@@ -8087,7 +8091,7 @@ function SearchSongList({
 
   return (
     <div className="track-list song-browser-list" ref={setSongListRef} tabIndex={0} onKeyDown={handleKeyDown} role="list" aria-label="Songs">
-      <SongListHeader showTrackNumber={false} sortKey={sortKey} sortDirection={sortDirection} onSort={(key) => {
+      <SongListHeader showTrackNumber={false} sortKey={sortKey ?? undefined} sortDirection={sortDirection} onSort={(key) => {
         setSortDirection((direction) => key === sortKey ? (direction === "asc" ? "desc" : "asc") : "asc");
         setSortKey(key);
       }} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7882,8 +7882,24 @@ function SearchResultsView({
   onQueueSong: (song: Song) => void;
   onSongContextMenu: (event: MouseEvent<HTMLElement>, song: Song, selectedSongs?: Song[]) => void;
 }) {
+  const previewLimit = 8;
   const trimmedQuery = query.trim();
   const totalResults = results.artists.length + results.albums.length + results.songs.length + results.playlists.length;
+  const [resultFilter, setResultFilter] = useState<"all" | "songs" | "albums" | "artists" | "playlists">("all");
+  const [expandedSections, setExpandedSections] = useState<Set<"songs" | "albums" | "artists" | "playlists">>(() => new Set());
+  const filters = [
+    ["all", "All", totalResults],
+    ["songs", "Songs", results.songs.length],
+    ["albums", "Albums", results.albums.length],
+    ["artists", "Artists", results.artists.length],
+    ["playlists", "Playlists", results.playlists.length],
+  ] as const;
+  const shows = (type: Exclude<typeof resultFilter, "all">) => resultFilter === "all" || resultFilter === type;
+  const visible = <T,>(type: "songs" | "albums" | "artists" | "playlists", items: T[]) => expandedSections.has(type) ? items : items.slice(0, previewLimit);
+  const canShowMore = <T,>(type: "songs" | "albums" | "artists" | "playlists", items: T[]) => !expandedSections.has(type) && items.length > previewLimit;
+  const showMore = (type: "songs" | "albums" | "artists" | "playlists") => {
+    setExpandedSections((sections) => new Set(sections).add(type));
+  };
 
   if (trimmedQuery.length < 2) {
     return <EmptyPanel icon={<Search size={20} />} text="Start typing in the top search." />;
@@ -7905,24 +7921,30 @@ function SearchResultsView({
     <div className="search-results">
       <section className="search-summary">
         <div>
-          <p className="eyebrow">Search results</p>
           <h4>{trimmedQuery}</h4>
         </div>
-        <div className="search-counts" aria-label="Result counts">
-          <span>{results.songs.length} songs</span>
-          <span>{results.albums.length} albums</span>
-          <span>{results.artists.length} artists</span>
-          <span>{results.playlists.length} playlists</span>
+        <div className="search-counts" aria-label="Filter results by type">
+          {filters.map(([filter, label, count]) => (
+            <button
+              className={resultFilter === filter ? "active" : ""}
+              type="button"
+              key={filter}
+              onClick={() => setResultFilter(filter)}
+              aria-pressed={resultFilter === filter}
+            >
+              {label} {count}
+            </button>
+          ))}
         </div>
       </section>
-      {results.artists.length ? (
+      {shows("artists") && results.artists.length ? (
         <section className="search-section">
           <div className="section-label">
             <h4>Artists</h4>
             <small>{results.artists.length}</small>
           </div>
           <ArtistList
-            artists={results.artists}
+            artists={visible("artists", results.artists)}
             favoriteIds={favoriteIds}
             favoriteBusyKey={favoriteBusyKey}
             onToggleFavorite={onToggleFavorite}
@@ -7930,9 +7952,10 @@ function SearchResultsView({
             onPlayArtist={onPlayArtist}
             withAlphabetRail={false}
           />
+          {canShowMore("artists", results.artists) ? <button className="search-see-more" type="button" onClick={() => showMore("artists")}>See more artists ({results.artists.length - previewLimit})</button> : null}
         </section>
       ) : null}
-      {results.albums.length ? (
+      {shows("albums") && results.albums.length ? (
         <section className="search-section">
           <div className="section-label">
             <h4>Albums</h4>
@@ -7940,7 +7963,7 @@ function SearchResultsView({
           </div>
           <AlbumList
             config={config}
-            albums={results.albums}
+            albums={visible("albums", results.albums)}
             favoriteIds={favoriteIds}
             favoriteBusyKey={favoriteBusyKey}
             onToggleFavorite={onToggleFavorite}
@@ -7948,25 +7971,27 @@ function SearchResultsView({
             onPlayAlbum={onPlayAlbum}
             withAlphabetRail={false}
           />
+          {canShowMore("albums", results.albums) ? <button className="search-see-more" type="button" onClick={() => showMore("albums")}>See more albums ({results.albums.length - previewLimit})</button> : null}
         </section>
       ) : null}
-      {results.playlists.length ? (
+      {shows("playlists") && results.playlists.length ? (
         <section className="search-section">
           <div className="section-label">
             <h4>Playlists</h4>
             <small>{results.playlists.length}</small>
           </div>
-          <SearchPlaylistList playlists={results.playlists} onOpenPlaylist={onOpenPlaylist} />
+          <SearchPlaylistList playlists={visible("playlists", results.playlists)} onOpenPlaylist={onOpenPlaylist} />
+          {canShowMore("playlists", results.playlists) ? <button className="search-see-more" type="button" onClick={() => showMore("playlists")}>See more playlists ({results.playlists.length - previewLimit})</button> : null}
         </section>
       ) : null}
-      {results.songs.length ? (
+      {shows("songs") && results.songs.length ? (
         <section className="search-section">
           <div className="section-label">
             <h4>Songs</h4>
             <small>{results.songs.length}</small>
           </div>
           <SearchSongList
-            songs={results.songs}
+            songs={visible("songs", results.songs)}
             currentTrack={currentTrack}
             favoriteIds={favoriteIds}
             favoriteBusyKey={favoriteBusyKey}
@@ -7977,6 +8002,7 @@ function SearchResultsView({
             onQueueSong={onQueueSong}
             onSongContextMenu={onSongContextMenu}
           />
+          {canShowMore("songs", results.songs) ? <button className="search-see-more" type="button" onClick={() => showMore("songs")}>See more songs ({results.songs.length - previewLimit})</button> : null}
         </section>
       ) : null}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2088,7 +2088,6 @@ export function App() {
   const catalogSongsCompleteRef = useRef(false);
   const catalogSongSyncInFlightRef = useRef(false);
   const catalogHydratedKeyRef = useRef("");
-  const trackpadNavigationRef = useRef({ accumulatedDeltaX: 0, lastEventAt: 0, consumed: false });
   const [discordPresenceSyncNonce, setDiscordPresenceSyncNonce] = useState(0);
   const [discordPresenceStatus, setDiscordPresenceStatus] = useState<DiscordPresenceStatus>("idle");
   const navigationStateRef = useRef({
@@ -3304,40 +3303,6 @@ export function App() {
     window.history.forward();
   }
 
-  useEffect(() => {
-    const handleTrackpadNavigation = (event: WheelEvent) => {
-      // With WebKit's own history gesture disabled, horizontal trackpad
-      // movement reaches the page as wheel events. Consume a deliberate swipe
-      // here so Prism can use its own history without WebKit sliding the whole
-      // window surface.
-      if (Math.abs(event.deltaX) <= Math.abs(event.deltaY)) return;
-
-      const gesture = trackpadNavigationRef.current;
-      const now = performance.now();
-      if (now - gesture.lastEventAt > 180) {
-        gesture.accumulatedDeltaX = 0;
-        gesture.consumed = false;
-      }
-      gesture.lastEventAt = now;
-      gesture.accumulatedDeltaX += event.deltaX;
-
-      if (gesture.consumed || Math.abs(gesture.accumulatedDeltaX) < 80) return;
-
-      if (gesture.accumulatedDeltaX > 0 && backStack.length) {
-        gesture.consumed = true;
-        event.preventDefault();
-        window.history.back();
-      } else if (gesture.accumulatedDeltaX < 0 && forwardStack.length) {
-        gesture.consumed = true;
-        event.preventDefault();
-        window.history.forward();
-      }
-    };
-
-    window.addEventListener("wheel", handleTrackpadNavigation, { passive: false });
-    return () => window.removeEventListener("wheel", handleTrackpadNavigation);
-  }, [backStack.length, forwardStack.length]);
-
   function resetPlaybackPosition() {
     pendingResumePositionRef.current = 0;
     setPosition(0);
@@ -3777,7 +3742,9 @@ export function App() {
     const audio = getActiveAudio();
 
     if (isPlaying) {
-      stopTrackTransition(true);
+      // Cancelling a crossfade should clear the standby player, but pausing
+      // must leave the active element at its current position for resume.
+      stopTrackTransition();
       setIsPlaying(false);
       return;
     }
@@ -4550,7 +4517,7 @@ export function App() {
         setRadioMessage("Radio paused.");
         return;
       }
-      stopTrackTransition(true);
+      stopTrackTransition();
       setIsPlaying(false);
     });
     navigator.mediaSession.setActionHandler("previoustrack", controlsRadio ? null : playPrevious);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2088,6 +2088,7 @@ export function App() {
   const catalogSongsCompleteRef = useRef(false);
   const catalogSongSyncInFlightRef = useRef(false);
   const catalogHydratedKeyRef = useRef("");
+  const trackpadNavigationRef = useRef({ accumulatedDeltaX: 0, lastEventAt: 0, consumed: false });
   const [discordPresenceSyncNonce, setDiscordPresenceSyncNonce] = useState(0);
   const [discordPresenceStatus, setDiscordPresenceStatus] = useState<DiscordPresenceStatus>("idle");
   const navigationStateRef = useRef({
@@ -3302,6 +3303,40 @@ export function App() {
     if (!forwardStack.length) return;
     window.history.forward();
   }
+
+  useEffect(() => {
+    const handleTrackpadNavigation = (event: WheelEvent) => {
+      // With WebKit's own history gesture disabled, horizontal trackpad
+      // movement reaches the page as wheel events. Consume a deliberate swipe
+      // here so Prism can use its own history without WebKit sliding the whole
+      // window surface.
+      if (Math.abs(event.deltaX) <= Math.abs(event.deltaY)) return;
+
+      const gesture = trackpadNavigationRef.current;
+      const now = performance.now();
+      if (now - gesture.lastEventAt > 180) {
+        gesture.accumulatedDeltaX = 0;
+        gesture.consumed = false;
+      }
+      gesture.lastEventAt = now;
+      gesture.accumulatedDeltaX += event.deltaX;
+
+      if (gesture.consumed || Math.abs(gesture.accumulatedDeltaX) < 80) return;
+
+      if (gesture.accumulatedDeltaX > 0 && backStack.length) {
+        gesture.consumed = true;
+        event.preventDefault();
+        window.history.back();
+      } else if (gesture.accumulatedDeltaX < 0 && forwardStack.length) {
+        gesture.consumed = true;
+        event.preventDefault();
+        window.history.forward();
+      }
+    };
+
+    window.addEventListener("wheel", handleTrackpadNavigation, { passive: false });
+    return () => window.removeEventListener("wheel", handleTrackpadNavigation);
+  }, [backStack.length, forwardStack.length]);
 
   function resetPlaybackPosition() {
     pendingResumePositionRef.current = 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7245,7 +7245,7 @@ function LibraryView({
         />
       ) : (
         <>
-          {activeView !== "overview" && activeView !== "nowPlaying" ? (
+          {activeView !== "overview" && activeView !== "nowPlaying" && activeView !== "search" ? (
             <div className="panel-heading browser-heading">
               <h3>{panelTitle}</h3>
               <div className="heading-actions">
@@ -7921,9 +7921,6 @@ function SearchResultsView({
   return (
     <div className="search-results">
       <section className="search-summary">
-        <div>
-          <h4>{trimmedQuery}</h4>
-        </div>
         <div className="search-counts" aria-label="Filter results by type">
           {filters.map(([filter, label, count]) => (
             <button

--- a/src/styles.css
+++ b/src/styles.css
@@ -106,6 +106,8 @@ textarea {
   grid-template-rows: minmax(0, 1fr) 94px;
   width: 100vw;
   height: 100vh;
+  /* Keep native trackpad back/forward swipes inside Prism's own navigation. */
+  overscroll-behavior: none;
   background:
     radial-gradient(circle at 15% 20%, rgba(var(--prism-glow-left-rgb), 0.28), transparent 34%),
     radial-gradient(circle at 74% 22%, rgba(var(--prism-glow-right-rgb), 0.22), transparent 38%),

--- a/src/styles.css
+++ b/src/styles.css
@@ -1470,17 +1470,33 @@ body.right-sidebar-resizing .right-sidebar-resize-handle::after {
   color: rgba(244, 241, 236, 0.7);
 }
 
+.home-now-playing-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.home-now-playing-meta > [aria-hidden="true"] {
+  display: none;
+}
+
 .home-now-playing-meta-link {
-  padding: 0;
-  color: inherit;
+  min-height: 28px;
+  padding: 5px 9px;
+  border-radius: 999px;
+  background: rgba(13, 13, 12, 0.5);
+  color: rgba(255, 255, 255, 0.94);
   font: inherit;
+  font-size: 13px;
+  line-height: 1.2;
   text-align: inherit;
 }
 
 .home-now-playing-meta-link:hover,
 .home-now-playing-meta-link:focus-visible {
-  color: var(--prism-accent-strong);
-  text-decoration: underline;
+  background: rgba(var(--prism-accent-rgb), 0.3);
+  color: #fff;
 }
 
 .home-playback-controls {
@@ -3758,7 +3774,6 @@ button.similar-chip:hover,
 }
 
 .search-summary h4 {
-  margin-top: 3px;
   color: #f4f1ec;
   font-size: 18px;
   font-weight: 500;
@@ -3771,7 +3786,7 @@ button.similar-chip:hover,
   gap: 6px;
 }
 
-.search-counts span {
+.search-counts button {
   min-height: 24px;
   padding: 5px 9px;
   border-radius: 999px;
@@ -3780,9 +3795,32 @@ button.similar-chip:hover,
   font-size: 11px;
 }
 
+.search-counts button:hover,
+.search-counts button:focus-visible,
+.search-counts button.active {
+  background: rgba(var(--prism-accent-rgb), 0.2);
+  color: var(--prism-highlight);
+}
+
 .search-section {
   display: grid;
   gap: 8px;
+}
+
+.search-see-more {
+  justify-self: start;
+  min-height: 28px;
+  padding: 5px 9px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(244, 241, 236, 0.84);
+  font-size: 12px;
+}
+
+.search-see-more:hover,
+.search-see-more:focus-visible {
+  background: rgba(var(--prism-accent-rgb), 0.2);
+  color: var(--prism-highlight);
 }
 
 .section-label small {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3765,26 +3765,19 @@ button.similar-chip:hover,
 }
 
 .search-summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-  min-height: 58px;
-  padding: 12px 14px;
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.055);
-}
-
-.search-summary h4 {
-  color: #f4f1ec;
-  font-size: 18px;
-  font-weight: 500;
+  position: sticky;
+  top: -14px;
+  z-index: 2;
+  margin: -14px -14px 0;
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(13, 15, 14, 0.94);
+  backdrop-filter: blur(18px);
 }
 
 .search-counts {
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-end;
   gap: 6px;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -106,7 +106,7 @@ textarea {
   grid-template-rows: minmax(0, 1fr) 94px;
   width: 100vw;
   height: 100vh;
-  /* Keep native trackpad back/forward swipes inside Prism's own navigation. */
+  /* Avoid scroll chaining from nested content to the window. */
   overscroll-behavior: none;
   background:
     radial-gradient(circle at 15% 20%, rgba(var(--prism-glow-left-rgb), 0.28), transparent 34%),

--- a/src/styles.css
+++ b/src/styles.css
@@ -3769,15 +3769,27 @@ button.similar-chip:hover,
   top: -14px;
   z-index: 2;
   margin: -14px -14px 0;
-  padding: 10px 14px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(13, 15, 14, 0.94);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  min-height: 58px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.055);
   backdrop-filter: blur(18px);
+}
+
+.search-summary h4 {
+  color: #f4f1ec;
+  font-size: 18px;
+  font-weight: 500;
 }
 
 .search-counts {
   display: flex;
   flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 6px;
 }
 


### PR DESCRIPTION
## Outcome

Polish Prism search results and make macOS navigation, startup placement, and local playback reliable.

## Changes

- Add result-type filters for All, Songs, Albums, Artists, and Playlists.
- Keep each search section to eight items until its `See more` action is selected.
- Remove the redundant `Search results` eyebrow while keeping the query visible.
- Preserve song-row selection and make search metadata navigation explicit.
- Improve playlist table sorting without rewriting saved playlist order.
- Turn local Now Playing artist and album links into readable, high-contrast metadata chips.
- Restore native macOS trackpad back/forward navigation.
- Validate the restored window position before showing the app, preventing an offscreen startup flash.
- Preserve local playback position when pausing from in-app and system controls. Closes #174.

## Validation

- `npm run lint`
- `npm run build`
- `cargo check`
- macOS test artifact running in GitHub Actions.

## Notes

- No deployment or release is included.
- The local Rust formatter component is unavailable; `cargo fmt --check` could not run.
- Existing repository Dependabot advisory remains: one moderate default-branch vulnerability reported by GitHub.

Closes #169
Closes #170
